### PR TITLE
Reject most selector tests with one AND: a one-sided element signature in the matcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,13 @@ jobs:
       # correctness gate: 0 non-whitespace DIVERGE + 0 CRASH vs lxml (flat AND grouped One/Many)
       - run: .venv/bin/python tools/diff_lxml.py
       - run: .venv/bin/python tools/enc_check.py
+      # The extension has to exist from here on: `diff_fuzz.py` reads the engine's tag tables through
+      # `audit_tree_rules`, which imports `frostwork`, and `bench_corpus.py` extracts through it. Building
+      # it later (as this job used to) made every one of those steps a ModuleNotFoundError the moment the
+      # fuzzer grew that import — a gate that cannot even start. It does NOT disturb the `differ`/`bench`
+      # bins built above: this compiles the lib under a different feature set and leaves the existing
+      # binaries in place (nothing rebuilds them after, which is what would matter — see AGENTS.md).
+      - run: .venv/bin/maturin develop --release
       # differential fuzz: mutate well-formed pages into MALFORMED HTML and diff vs lxml. DIVERGE is
       # expected here (documented foster-parenting / adoption-agency SKIP set), so only CRASH is gated
       # (--gate): any panic on any input is a real bug. Catches tokenizer desync (e.g. comment-close)
@@ -64,12 +71,10 @@ jobs:
       # the no-fallback contract — a column is empty OR equals lxml, never non-empty-and-wrong, never a
       # crash. Gates WRONG (disagree) + OVERMATCH (data on a parsel-invalid selector) + CRASH.
       - run: .venv/bin/python tools/sel_fuzz.py --iters 6000 --gate
-      # build the extension into the venv, then exercise the Python surface (extract, Page, FrostPage,
-      # Many/One) AND tests/test_gates.py, which seeds a known regression into each gate's decision
-      # function and asserts it goes red. `tests/` not `tests/test_python.py`: the gate meta-tests were
-      # written and then not run by either `make ci` or this workflow, which is the exact failure they
-      # exist to catch.
-      - run: .venv/bin/maturin develop --release
+      # exercise the Python surface (extract, Page, FrostPage, Many/One) AND tests/test_gates.py, which
+      # seeds a known regression into each gate's decision function and asserts it goes red. `tests/` not
+      # `tests/test_python.py`: the gate meta-tests were written and then not run by either `make ci` or
+      # this workflow, which is the exact failure they exist to catch.
       - run: .venv/bin/python -m pytest tests/ -q
       - run: .venv/bin/python tools/support_snapshot.py --check
       # Page coverage is not RULE coverage: this enumerates every tree-construction rule cell against

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,9 @@ Two limits of that gate are worth knowing before trusting a "100% parity" number
   `matcher/` — **the real logic**: `mod.rs` (corrected-stack matcher: `CompiledSchema` compile +
   `Matcher` streaming execute), `compile.rs` (routing eligibility: which selector shapes execute
   faithfully vs. stay unsupported), `matching.rs` (pure read-only match predicates), `deferred.rs`
-  (bounded state machines for deferred-close predicates), `decode.rs` (value decoding).
+  (bounded state machines for deferred-close predicates), `decode.rs` (value decoding),
+  `sig.rs` (the ONE-SIDED element/compound Bloom signatures `compound_matches` opens with — a set bit
+  is necessary, never sufficient; read its header before touching the hash).
   `selector.rs` (CSS parse), `xpath.rs` (downward XPath → `Selector`), `diagnostics.rs`
   (advisory unsupported-reason classifier for the audit API), `implied_close.rs` (libxml2
   tree-construction rules), `encoding.rs`, `entities.rs`, `mutate.rs` (an identity function unless built

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 #   make gate-mutate-full  every cell (~2,200 mutants, ~15 min with the fast gates) — nightly
 #   make soak        multi-million differential/fuzz soak across independent seeds
 #   make py          rebuild the extension (maturin --release), Python suite + tree-rule audit
-#   make bench       full throughput matrix vs Parsel (minutes; for release notes)
+#   make bench       full throughput matrix vs Parsel (~1 h — Parsel dominates it; for release notes)
 #   make bench-smoke quick article/deep-nesting performance check
 #   make ci          test + gate + gate-corpus + fuzz-smoke + py — minimum pre-release check
 #

--- a/Makefile
+++ b/Makefile
@@ -102,5 +102,10 @@ bench: build
 bench-smoke: build
 	$(PY) tools/bench_matrix.py --smoke
 
-ci: test gate gate-corpus fuzz-smoke py
+# `py` runs THIRD, not last: it builds the extension, and both `gate-corpus` (bench_corpus.py extracts
+# through it) and `fuzz-smoke` (diff_fuzz.py reads the tag tables via audit_tree_rules) import it. With
+# `py` at the end, this target died on a ModuleNotFoundError in any venv where the extension wasn't
+# already installed — the gates after it never ran at all, which no amount of them going red would have
+# told you. Same reason the workflow builds it before its fuzz steps.
+ci: test gate py gate-corpus fuzz-smoke
 	@echo "frostwork: all local gates passed"

--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ in a subtree — `div:has(a) a::attr(href)` — re-reads just that element's spa
 on the workload, so each one below names its own; [docs/BENCHMARKS.md](docs/BENCHMARKS.md) is the
 canonical source and the only place they are maintained:
 
-- **12–20×** faster than Parsel on realistic synthetic pages at typical field counts, up to **40–54×**
-  on selector-rich schemas (the Rust benchmark matrix).
+- **11–20×** faster than Parsel on realistic synthetic pages at typical field counts, up to **50–61×**
+  on selector-rich schemas (the Rust benchmark matrix). A single-field schema is the weak case (3–6×):
+  the advantage comes from answering a whole schema in one pass.
 - **10.5×** median (12.4× aggregate) on Zyte's production-selector corpus — 788 real pages, each with
-  its own production selectors, through the Python binding.
+  its own production selectors, through the Python binding (measured before the matcher's signature
+  filter landed, so a floor).
 
 Working memory stays small because Frostwork retains parser state and pending matches, not a tree
 containing the whole page.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -5,45 +5,81 @@ parse once, then one `.css()` per field). Both run the **same** selectors on the
 every page/selector pair is **byte-identical between the two** (verified: 32/32 AGREE per page), so
 each cell is a fair "extract N fields from this page" comparison. Single machine (Apple arm64),
 warm; indicative, not a controlled benchmark. Selector pool is a realistic product/article mix;
-counts are prefixes of it. Reproduce: `.venv/bin/python tools/bench_matrix.py`.
+counts are prefixes of it. Reproduce: `.venv/bin/python tools/bench_matrix.py` (~1 h; Parsel's cells
+dominate it).
+
+Every table here except the two at the end (real corpus, memory — they need a corpus this repo does not
+ship) comes from **one** run of that command, so the cells are comparable to each other. They are **not**
+comparable to a previous publication of this file: absolute µs move 5–10% with machine state, which is
+more than many changes are worth. Measuring a change therefore means running both builds *interleaved
+within each cell* (build each to its own `bench` binary, alternate them, take min-of-N) — see the
+signature-filter deltas in [DESIGN.md](DESIGN.md#performance-decisions-all-validated-against-the-gate).
 
 ## Page type × selector count (µs/page)
 
 | page (≈196 KB) | sels | engine µs | engine MB/s | Parsel µs | speedup |
 | --- | --- | --- | --- | --- | --- |
-| **article** (text-heavy) | 1 | 58 | 3451 | 560 | 9.6× |
-|  | 4 | 136 | 1475 | 2706 | 19.9× |
-|  | 8 | 270 | 745 | 5324 | 19.8× |
-|  | 16 | 358 | 560 | 6427 | 17.9× |
-|  | 26 | 479 | 419 | 9686 | 20.2× |
-|  | 32 | 556 | 361 | 11212 | 20.2× |
-| **product&#95;listing** | 1 | 256 | 782 | 2619 | 10.2× |
-|  | 4 | 747 | 268 | 15313 | 20.5× |
-|  | 8 | 1068 | 188 | 22123 | 20.7× |
-|  | 16 | 1838 | 109 | 80254 | 43.7× |
-|  | 26 | 2671 | 75 | 144615 | 54.1× |
-|  | 32 | 2924 | 68 | 144178 | 49.3× |
-| **table-heavy** | 1 | 360 | 556 | 3192 | 8.9× |
-|  | 8 | 1029 | 195 | 13432 | 13.1× |
-|  | 16 | 1814 | 110 | 44571 | 24.6× |
-|  | 32 | 3550 | 56 | 98915 | 27.9× |
-| **deep-nested** (20-deep) | 1 | 619 | 324 | 3211 | 5.2× |
-|  | 8 | 1296 | 154 | 12560 | 9.7× |
-|  | 16 | 2252 | 89 | 41175 | 18.3× |
-|  | 32 | 3861 | 52 | 57569 | 14.9× |
-| **corpus** (real-shaped, 567 KB) | 1 | 175 | 3322 | 2070 | 11.8× |
-|  | 8 | 712 | 815 | 8661 | 12.2× |
-|  | 16 | 1346 | 431 | 67613 | 50.2× |
-|  | 26 | 1880 | 309 | 83608 | 44.5× |
-|  | 32 | 2094 | 277 | 85213 | 40.7× |
+| **article** (text-heavy) | 1 | 91 | 2217 | 565 | 6.2× |
+|  | 4 | 198 | 1012 | 2805 | 14.2× |
+|  | 8 | 299 | 670 | 5508 | 18.4× |
+|  | 16 | 359 | 560 | 6537 | 18.2× |
+|  | 26 | 482 | 416 | 9995 | 20.7× |
+|  | 32 | 575 | 349 | 11300 | 19.6× |
+| **product&#95;listing** | 1 | 526 | 380 | 2916 | 5.5× |
+|  | 4 | 1108 | 181 | 15335 | 13.8× |
+|  | 8 | 1366 | 147 | 21957 | 16.1× |
+|  | 16 | 2035 | 98 | 81241 | 39.9× |
+|  | 26 | 2784 | 72 | 146968 | 52.8× |
+|  | 32 | 3066 | 65 | 147831 | 48.2× |
+| **table-heavy** | 1 | 619 | 323 | 3182 | 5.1× |
+|  | 4 | 1146 | 175 | 13205 | 11.5× |
+|  | 8 | 1256 | 159 | 13535 | 10.8× |
+|  | 16 | 1960 | 102 | 44934 | 22.9× |
+|  | 26 | 2805 | 71 | 81940 | 29.2× |
+|  | 32 | 3411 | 59 | 98707 | 28.9× |
+| **deep-nested** (20-deep) | 1 | 1010 | 198 | 3257 | 3.2× |
+|  | 4 | 1361 | 147 | 10518 | 7.7× |
+|  | 8 | 1687 | 119 | 12684 | 7.5× |
+|  | 16 | 2531 | 79 | 39293 | 15.5× |
+|  | 26 | 3405 | 59 | 54797 | 16.1× |
+|  | 32 | 4169 | 48 | 55607 | 13.3× |
+
+The matrix also picks up a page from `fixtures/` when one is present. That directory is gitignored
+(real snapshots are a licensing/size call), so the row is absent here rather than carried over stale
+from a page this checkout cannot re-measure.
+
+## Class-led schema × field count (the matcher's own regime)
+
+Utility-CSS markup — every element carries 4–8 `class=` tokens, the shape Tailwind-style sites emit —
+queried by N **class-led** fields, most of which deliberately miss (a real schema is written for one
+site's template, and its misses still cost a test per element). This is where per-`(element, selector)`
+matching work dominates, so it is the table a matcher change shows up in; the tag-led pool over the
+same page is repeated underneath as the contrast (a tag test is one `memcmp`, so it exercises far less
+of it). Both from the same run as above; `tools/bench_matrix.py --class-led` runs just these two.
+
+| schema | fields | engine µs | engine MB/s | vals/page | Parsel µs | speedup |
+| --- | --- | --- | --- | --- | --- | --- |
+| **class-led** | 4 | 706 | 284 | 1760 | 13231 | 18.7× |
+|  | 8 | 1009 | 199 | 3520 | 35744 | 35.4× |
+|  | 16 | 1126 | 178 | 3520 | 55049 | 48.9× |
+|  | 32 | 1521 | 132 | 3520 | 93471 | 61.4× |
+| **tag-led** (same page) | 4 | 651 | 308 | 1320 | — | — |
+|  | 8 | 809 | 248 | 2640 | — | — |
+|  | 16 | 1111 | 180 | 5720 | — | — |
+|  | 32 | 1523 | 132 | 7920 | — | — |
+
+Engine cost rises **sub-linearly** in field count here — 4→32 class-led fields is 8× the schema for
+2.2× the time — because the one-sided signature filter rejects most `(element, compound)` pairs in one
+AND before any string comparison, and the pass itself is shared. Parsel's rises **linearly-plus**
+(7.1× for the same 8× schema), which is what widens the ratio from 19× to 61×.
 
 ## Size sweep (product_listing, 8 selectors)
 
 | size | engine µs | engine MB/s | Parsel µs | speedup |
 | --- | --- | --- | --- | --- |
-| 19 KB | 111 | 181 | 2176 | 19.6× |
-| 195 KB | 1068 | 188 | 21545 | 20.2× |
-| 976 KB | 5285 | 189 | 110631 | 20.9× |
+| 19 KB | 144 | 141 | 2234 | 15.6× |
+| 195 KB | 1360 | 147 | 22020 | 16.2× |
+| 976 KB | 6791 | 147 | 111313 | 16.4× |
 
 ## Grouped (Many/One) — `.product` container × N sub-fields
 
@@ -53,35 +89,58 @@ One `Many` group over the product listing (195 KB, ~50 `.product` cards), engine
 
 | subs | engine µs | engine MB/s | vals/page | Parsel µs | speedup |
 | --- | --- | --- | --- | --- | --- |
-| 1 | 735 | 273 | 1006 | 14160 | 19.3× |
-| 3 | 1064 | 188 | 3018 | 34401 | 32.3× |
-| 5 | 1363 | 147 | 5030 | 55125 | 40.4× |
+| 1 | 843 | 238 | 1006 | 13790 | 16.4× |
+| 3 | 1161 | 172 | 3018 | 33378 | 28.7× |
+| 5 | 1424 | 141 | 5030 | 52708 | 37.0× |
 
-The engine's grouped cost grows **sub-linearly** in sub count (735 → 1064 → 1363 µs for 1 → 3 → 5
+The engine's grouped cost grows **sub-linearly** in sub count (843 → 1161 → 1424 µs for 1 → 3 → 5
 subs — the pass and per-element bookkeeping are shared; only the per-instance × per-sub match adds),
 while Parsel's per-container loop grows **linearly** (it re-runs each sub-selector against every
 container node). So the per-instance on-demand evaluation is healthy — no super-linear blow-up even
 at 5 000 emitted cells/page — and needs no optimization at these schema sizes.
 
+## Deferred tails — N tail fields vs N plain fields (product_listing)
+
+A deferred predicate whose value lives in a subtree (`div:has(a) a::attr(href)`, `li:last-child a::attr(href)`)
+re-scans each winner's span instead of streaming, and each one is its own sub-schema — so unlike ordinary
+fields they do **not** share the pass, and the cost grows with field count. Kept as its own table so that
+stays visible rather than averaged into the headline numbers.
+
+| fields | tail µs | plain µs | tail/plain |
+| --- | --- | --- | --- |
+| 1 | 1097 | 430 | 2.6× |
+| 2 | 1679 | 602 | 2.8× |
+| 4 | 3715 | 1016 | 3.7× |
+| 8 | 5812 | 1378 | 4.2× |
+
+If that ratio ever matters for a real schema, the fix is merging tails that share a deferred prefix into
+one sub-schema — not yet needed at these field counts.
+
 ## Reading the numbers
 
-- **Typical speedup \~10–20×, rising to \~40–54× on selector-rich pages.** The engine's cost grows
-  roughly linearly with selector count and page size; Parsel's grows **super-linearly** once selectors
+- **Typical speedup \~11–20×, rising to \~50–61× on selector-rich pages.** The engine's cost grows
+  sub-linearly with selector count (the pass is shared, and the signature filter rejects most
+  `(element, compound)` pairs before any string work); Parsel's grows **super-linearly** once selectors
   get descendant-heavy (`.product .price`, `.product ::text`) — cssselect translates each to XPath and
-  libxml2 re-walks per query, so at 16–32 fields Parsel balloons to 80–145 ms while the engine's single
-  pass stays in single-digit ms. The one-pass, no-DOM design is what widens the gap with field count.
-- **Constant speedup across size** (~20× from 19 KB to ~1 MB): both scale linearly, engine at a steady
-  ~189 MB/s on this page type.
-- **Throughput is page-shape-dependent.** Text-dominated pages (article, corpus) run 0.8–3.5 GB/s
-  because memchr bulk-skips text; tag-dense pages (table, listing, deep-nest) run 50–800 MB/s because
-  cost is per-element (classify + stack + per-selector match), not per-byte.
-- **Weak spot — deep nesting.** 20-level-deep pages are the engine's worst case (5–18×, and 619 µs for
+  libxml2 re-walks per query, so at 16–32 fields Parsel balloons to 80–148 ms while the engine's single
+  pass stays in single-digit ms. That divergence, not a constant factor, is what the no-DOM design buys.
+- **Constant speedup across size** (~16× from 19 KB to ~1 MB): both scale linearly, engine at a steady
+  ~147 MB/s on this page type.
+- **Throughput is page-shape-dependent.** Text-dominated pages (the article) run up to ~2.2 GB/s at one
+  field because memchr bulk-skips text; tag-dense pages (table, listing, deep-nest) run 48–380 MB/s
+  because cost is per-element (classify + stack + per-selector match), not per-byte.
+- **Weak spot — deep nesting.** 20-level-deep pages are the engine's worst case (3–16×, and 1010 µs for
   a single selector): structural matching walks the ancestor stack per element (`seg_match`), so cost
   rises with depth. Real pages are rarely this deep; still, it's the honest floor. (Parsel is *also*
-  slow here, so the ratio holds up, but the engine's absolute µs is high.)
+  slow here, so the ratio holds up, but the engine's absolute µs is high.) The signature filter helps
+  least here — it rejects at the subject, while the cost is the ancestor walk; an ancestor-signature
+  variant is the obvious next lever (see `matcher/sig.rs`).
+- **A single-field schema is the weakest case for the engine** (3–6×): one pass costs what it costs, and
+  there is almost nothing for the filter or the shared scan to amortize. The advantage is a *schema*
+  property, not a per-selector one.
 
-Net: on realistic pages (article, product listings, the real-shaped corpus) the engine is **~12–20× at
-typical field counts and up to ~40–54× on rich schemas**.
+Net: on realistic pages the engine is **~11–20× at typical field counts and up to ~50–61× on rich
+schemas**, with class-led schemas — what real page objects look like — at the top of that range.
 
 ## Real Zyte corpus (throughput)
 
@@ -97,6 +156,11 @@ release-first — see below).
 | metric | Frostwork | Parsel | speedup |
 | --- | --- | --- | --- |
 | median µs/page | 300 (494 MB/s) | 3 382 | **10.5×** (median), **12.4×** (aggregate) |
+
+> This row and the memory section below **predate the signature filter** and could not be re-measured
+> here: that corpus is not in the repo. Their production selectors are class-led with a median of 11
+> fields per page — the regime the class-led table shows the filter helping most — so treat these as a
+> conservative floor rather than current numbers, and re-run them wherever the corpus lives.
 
 Value parity with lxml is proven separately by the differential gate ([TESTING.md](TESTING.md)), not
 this timing run.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -35,6 +35,16 @@ bytes ─▶ tokenizer (TokenSink: start/text/end) ─▶ corrected-stack matche
   feasible position, right to left. Greedy is sound because a deeper placement leaves strictly more room
   above (exchange argument), and grouping `>`-runs is what makes it sound: greedy on individual compounds
   gets `a > b c` against `<a><b><b><c>` wrong. Searching combinations instead was exponential.
+  Before any of that runs, each `(element, compound)` pair meets a **one-sided signature filter**
+  (`matcher/sig.rs`, the shape of WebKit/Blink's `SelectorFilter`): at open, an element hashes its tag
+  name, `id` and each `class` token to two bits each of a `u64`; each compiled compound carries the same
+  bits for its own positive tag/id/classes; `compound_matches` opens with `el.sig & c.req != c.req →
+  false`. One AND rejects most pairs before a string is touched. A set bit is **necessary, never
+  sufficient** — collisions produce false positives, which cost only the exact comparisons that always
+  ran, while a false negative would be a silently dropped value. So the hash must mirror each
+  predicate's own equality: the tag is ASCII-folded on both sides (`eq_ignore_ascii_case`), `id` and
+  class tokens are hashed verbatim (`==`), and nothing is contributed by `:not()` (inverted), `:is()`
+  (an OR), attribute predicates, or positions.
 - **Selectors** — `selector.rs` parses the CSS subset; `xpath.rs` compiles the **downward** XPath
   subset to the *same* `Selector` model (so XPath and CSS share matching + performance).
 
@@ -194,12 +204,32 @@ descendant's emission and stays an empty column.
   the parse cost per *schema*, not per *page*. The per-page recompile it removes is negligible against
   a large page's scan, but on small pages it dominates: ~3× fewer µs/page on a 244-byte page with 8
   selectors. `extract`/`extract_grouped` remain as one-shot convenience (a throwaway `Plan`).
+- **One-sided signature filter** (`matcher/sig.rs`, described under *Pipeline*) — the matcher's cost is
+  `selectors × elements`, and before this every pair paid string work: a `memcmp` per tag test, and per
+  class test an `attrs` scan plus a fresh `split_whitespace` of `class=`. The filter answers "could this
+  compound match at all?" in one AND. It is where the *class-led, high-field-count* schema — the shape
+  real page objects have — gets most of its time back; measured against the pre-filter build on the
+  class-heavy page (`tools/bench_matrix.py --class-led`): −18% at 4 class-led fields, −31% at 8, −50% at
+  16, −63% at 32; on the product listing −16% at 8 and −31% at 32; and −2% to −28% on the tag-led pools,
+  which use the filter far less (a tag test is one `memcmp`). Signatures are built per start tag, so each
+  KIND of bit is included only for a schema that performs at least two tests of that kind
+  (`sig::BITS_MIN`) — below that the bits leave both sides, because hashing every element's class list to
+  save one comparison is a loss (measured: −11% before this rule, ±1% after). Compile pays ~0.4 µs more
+  per schema (11 selectors), which the `Plan` reuse model amortizes to nothing but a one-shot `extract`
+  on a ~1 KB page can still see as a percent or two.
 - **Rejected by measurement (do not re-attempt without a workload that shows a win):** a SIMD
-  structural index (the base scan is per-*element* bound, not per-byte; memchr already bulk-skips text)
-  and a subject-tag dispatch index (real selectors are class-led, so it can't bucket them).
+  structural index (the base scan is per-*element* bound, not per-byte; memchr already bulk-skips text);
+  a subject-tag dispatch index (real selectors are class-led, so it can't bucket them); **caching each
+  element's split `class=` tokens** on the open-element stack (inline `(start, len)` ranges, no
+  allocation) — on its own it was worth −27% to −51% on class-led schemas, but on top of the signature
+  filter it added only ~3% at 8+ class fields while taxing every other workload ~8–11% for the 40 bytes
+  it added to each stack element, so it was reverted; and an **eight-bytes-per-multiply hash** for the
+  signature (word load + whole-word case fold), which measured no faster than byte-at-a-time FNV-1a
+  because short tokens pay a variable-length copy per word.
 
-Result: ~12–20× Parsel on realistic pages at typical field counts, up to ~40–54× on rich schemas — the
-one-pass advantage grows with field count. Numbers + methodology: [BENCHMARKS.md](BENCHMARKS.md).
+Result: ~11–20× Parsel on realistic pages at typical field counts, up to ~50–61× on rich schemas — the
+one-pass advantage grows with field count, and a one-field schema is the weak case (3–6×). Numbers +
+methodology: [BENCHMARKS.md](BENCHMARKS.md).
 
 ## Page-object layer
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -40,6 +40,17 @@ family (`li`/`p`/`td`/`tr`/`dt`/`dd`/`option`) × {closed, omitted}; void/self-c
 combinators, `:not()`, comma groups; encoding resolution; XPath compilation; the `Page` layer; budget
 safety; and a regression vector for every bug the fuzzers have found.
 
+**Kernel equivalence sweeps** (`src/matcher/matching.rs`). Where a matcher optimization is supposed to
+be *invisible*, the unfiltered/previous form is kept reachable as a reference oracle and the two are
+compared over a generated sweep rather than hand-picked vectors — hand-picked vectors pass exactly when
+the author already understood the failure. Two run today: the anchored-glob ancestor walk against the
+original recursive walk (every pattern ≤ 4 compounds × every stack ≤ depth 5 × every
+subject/floor/strict/anchor), and the one-sided signature filter against the same predicate with the
+filter compiled out (`filter_never_rejects_a_match`, every combination of tag/id/class-set on both sides
+plus `:not()`/`:is()` wrappers, which must contribute no required bits). The filter sweep also asserts
+that it *rejects* a third of the pairs — an equivalence test alone would pass a filter that had been
+accidentally disabled.
+
 **Tokenizer conformance** (`src/tokenizer.rs`, `cargo test tokenizer`). The states that would cause a
 *global* offset desync must be exact. A recording `TokenSink` pins the event stream for each: RAWTEXT
 (`<script>` keeping `</b>` as text), RCDATA (`<title>`), comment close boundaries (incl. `<!-->` /

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -960,6 +960,41 @@ mod tests {
     fn class_and_id() {
         assert_eq!(ex("<div class=\"c\"><span id=\"x\">s</span></div>", ".c #x::text"), v(&["s"]));
     }
+    /// End to end through the signature filter (see `matcher::sig`), which hashes the tag folded and the
+    /// id/class tokens verbatim because that is how the predicates compare them: a mixed-case TAG must
+    /// still match, a wrong-case class or id must still not. Getting either backwards in the hash is a
+    /// silently dropped value, and only a case-MISMATCHED vector can see it.
+    #[test]
+    fn class_and_id_case_rules_survive_the_signature_filter() {
+        let h = "<DIV class=\"Foo bar\" id=\"Bar\"><p>x</p></DIV>";
+        // Selectors with TWO class tests are above the filter's class-bit cost threshold, so these are
+        // the ones that exercise class hashing; the single-class forms below cover the other regime.
+        for hit in ["div.Foo.bar#Bar", "DIV.Foo.bar", ".bar.Foo", "div.Foo#Bar", "dIv.Foo", "#Bar", ".Foo"] {
+            assert_eq!(ex(h, &format!("{hit} p::text")), v(&["x"]), "{hit}");
+        }
+        for miss in
+            ["div.foo.bar", "div.Foo.BAR", "DIV.FOO.bar", "div.foo", "div.FOO", "div#bar", "#BAR", ".foo"]
+        {
+            assert_eq!(ex(h, &format!("{miss} p::text")), v(&[]), "{miss}");
+        }
+    }
+    /// A utility-CSS class list, end to end. Every token of an element's `class=` is hashed into its
+    /// signature, so a long list must still match on ANY of them — early, late, or last — and must not
+    /// match a prefix or suffix of one. Run in both regimes: one class test (signature filters on the tag
+    /// alone) and two (class bits live), since only the second reaches the class hashing.
+    #[test]
+    fn long_class_list_matches_any_token() {
+        let h = "<div class=\"card product-card flex flex-col rounded-lg shadow-sm p-4 mb-2 last\">\
+                 <p class=\"one\">x</p></div>";
+        for hit in ["card", "flex-col", "mb-2", "last", "shadow-sm"] {
+            assert_eq!(ex(h, &format!(".{hit} p::text")), v(&["x"]), "class {hit}");
+            assert_eq!(ex(h, &format!(".card.{hit} p::text")), v(&["x"]), "class .card.{hit}");
+        }
+        for miss in ["car", "flex-", "ast", "p-", "card2"] {
+            assert_eq!(ex(h, &format!(".{miss} p::text")), v(&[]), "class {miss}");
+            assert_eq!(ex(h, &format!(".card.{miss} p::text")), v(&[]), "class .card.{miss}");
+        }
+    }
     #[test]
     fn attr_self() {
         assert_eq!(ex("<a href=\"/p?a=1&amp;b=2\">t</a>", "a::attr(href)"), v(&["/p?a=1&b=2"]));

--- a/src/matcher/matching.rs
+++ b/src/matcher/matching.rs
@@ -40,7 +40,30 @@ pub(super) fn reverse_matches(rev: &ReversePos, idx: u32, total: u32) -> bool {
 }
 
 /// Does compound `c` (tag / id / classes / attribute predicates / `:not()`) match element `el`?
+///
+/// Opens with the one-sided signature filter (see [`super::sig`]): one AND and one compare reject most
+/// (element, compound) pairs before any string is touched. A pair that survives falls through to the
+/// exact comparisons, unchanged — the filter is never allowed to answer `true`.
 pub(super) fn compound_matches(c: &Compound, el: &OpenElem) -> bool {
+    compound_matches_impl::<true>(c, el)
+}
+
+/// [`compound_matches`] with the signature filter switched OFF at every level — the reference the
+/// filtered path is proven equal to (`filter_never_rejects_a_match`). `FILTER` is a const generic
+/// rather than a copy of the body so the two paths cannot drift: there is one predicate here, and the
+/// only difference between the shipped and reference forms is whether the pre-filter runs.
+#[cfg(test)]
+pub(super) fn compound_matches_unfiltered(c: &Compound, el: &OpenElem) -> bool {
+    compound_matches_impl::<false>(c, el)
+}
+
+fn compound_matches_impl<const FILTER: bool>(c: &Compound, el: &OpenElem) -> bool {
+    // One-sided: a `req` bit the element lacks proves no match, so this can only turn a `false` into a
+    // faster `false`. `req` covers only the compound's own positive tag/id/classes — `:not()` args and
+    // `:is()` alternatives contribute nothing here and are filtered by their own recursive call below.
+    if FILTER && el.sig & c.req != c.req {
+        return false;
+    }
     if let Some(t) = &c.tag {
         if t != "*" && !el.tag.eq_ignore_ascii_case(t.as_bytes()) {
             return false;
@@ -78,14 +101,14 @@ pub(super) fn compound_matches(c: &Compound, el: &OpenElem) -> bool {
     }
     // `:not(<compound>)` — excluded if the element matches any negation arg
     for neg in &c.negations {
-        if compound_matches(neg, el) {
+        if compound_matches_impl::<FILTER>(neg, el) {
             return false;
         }
     }
     // `:is(...)`/`:where(...)` — for each group the element must match at least one alternative (OR
     // within a group, AND across groups). Alternatives are plain compounds (no positional/deferred).
     for group in &c.is_groups {
-        if !group.iter().any(|alt| compound_matches(alt, el)) {
+        if !group.iter().any(|alt| compound_matches_impl::<FILTER>(alt, el)) {
             return false;
         }
     }
@@ -308,8 +331,12 @@ mod seg_match_tests {
         go(&seg.parts, &seg.combs, seg.parts.len() - 1, stack, si, floor, anchor_bit, seg.strict)
     }
 
+    /// Compounds go through the compile step's `set_req`, exactly as the matcher's do — otherwise this
+    /// whole sweep would run with `req == 0` and never exercise the signature filter at all.
     fn compound(tag: &str) -> Compound {
-        Compound { tag: Some(tag.to_string()), ..Default::default() }
+        let mut c = Compound { tag: Some(tag.to_string()), ..Default::default() };
+        crate::matcher::sig::set_req_for_test(&mut c);
+        c
     }
 
     /// A stack of single-letter tags; `anchor` bit 0 is set on elements whose letter is uppercase, so
@@ -434,5 +461,176 @@ mod seg_match_tests {
         }
         // the old walk needed ~28 s for ONE subject at depth 40; this whole sweep is milliseconds
         assert!(t.elapsed().as_secs() < 2, "took {:?}", t.elapsed());
+    }
+}
+
+#[cfg(test)]
+mod sig_filter_tests {
+    use super::*;
+    use crate::matcher::sig;
+    use crate::selector::Compound;
+
+    /// A compound built the way the compile step builds one: fields set, then `set_req`.
+    fn cmp(tag: Option<&str>, id: Option<&str>, classes: &[&str]) -> Compound {
+        let mut c = Compound {
+            tag: tag.map(str::to_string),
+            id: id.map(str::to_string),
+            classes: classes.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        };
+        sig::set_req_for_test(&mut c);
+        c
+    }
+
+    fn el(tag: &'static [u8], attrs: &[(&'static [u8], &'static str)]) -> OpenElem<'static> {
+        OpenElem::for_test_attrs(tag, attrs)
+    }
+
+    /// The whole ballgame: the filter may only ever turn a `false` into a faster `false`. Over a spread
+    /// of elements and compounds — every combination of tag / id / class-set on both sides, plus
+    /// `:not()` and `:is()` wrappers whose bits must NOT be required — the filtered predicate must
+    /// agree with the same predicate run with the filter off. Wired like
+    /// `equivalent_to_reference_exhaustively`: the unfiltered path stays reachable as the oracle, so
+    /// this is a sweep rather than a handful of vectors that happen to hash the right way.
+    #[test]
+    fn filter_never_rejects_a_match() {
+        // element side: tag case, id case/absence, class lists that overlap the compound side
+        let tags: [&'static [u8]; 5] = [b"div", b"DIV", b"Div", b"span", b"a"];
+        let ids = [None, Some("Bar"), Some("bar"), Some("BAR"), Some("")];
+        let class_sets = [
+            None,
+            Some(""),
+            Some("Foo"),
+            Some("foo"),
+            Some("FOO"),
+            Some("Foo bar"),
+            Some("bar Foo baz"),
+            Some("foo Bar"),
+            Some("c1 c2 c3 c4 c5 c6 c7 c8 c9"), // a long utility-CSS-style list
+            // The signature hashes the tokens `split_whitespace` produces and `has_class` compares the
+            // tokens `split_whitespace` produces, so odd separators must not be able to pull them apart.
+            Some("  Foo   bar  "),
+            Some("Foo\tbar\nbaz\r\nqux"),
+            Some("Foo\u{a0}bar"), // NBSP: `split_whitespace` splits on it (Unicode, not the HTML set)
+            Some("café Foo"),
+        ];
+        // compound side: the same universe, so hits and misses both occur
+        let c_tags = [None, Some("*"), Some("div"), Some("DIV"), Some("span")];
+        let c_ids = [None, Some("Bar"), Some("bar"), Some("")];
+        let c_classes: [&[&str]; 7] =
+            [&[], &["Foo"], &["foo"], &["FOO"], &["Foo", "bar"], &["bar", "Foo"], &["café"]];
+
+        let mut compounds: Vec<Compound> = Vec::new();
+        for t in c_tags {
+            for i in c_ids {
+                for cl in c_classes {
+                    let base = cmp(t, i, cl);
+                    // `:not(<the same compound>)` — requiring its bits would invert the answer
+                    let mut neg = cmp(t, None, &[]);
+                    neg.negations.push(base.clone());
+                    sig::set_req_for_test(&mut neg);
+                    // `:is(a, b)` — an OR, so neither alternative's bits may be required
+                    let mut isg = cmp(t, None, &[]);
+                    isg.is_groups.push(vec![base.clone(), cmp(Some("span"), None, &["nope"])]);
+                    sig::set_req_for_test(&mut isg);
+                    compounds.extend([base, neg, isg]);
+                }
+            }
+        }
+
+        let mut checked = 0u64;
+        let mut filtered_out = 0u64;
+        for tag in tags {
+            for id in ids {
+                for cs in class_sets {
+                    let mut attrs: Vec<(&'static [u8], &'static str)> = Vec::new();
+                    if let Some(i) = id {
+                        attrs.push((b"id", i));
+                    }
+                    if let Some(c) = cs {
+                        attrs.push((b"class", c));
+                    }
+                    let e = el(tag, &attrs);
+                    for c in &compounds {
+                        let want = compound_matches_unfiltered(c, &e);
+                        assert_eq!(
+                            compound_matches(c, &e),
+                            want,
+                            "filter changed the answer: tag={:?} id={id:?} class={cs:?} req={:#x} \
+                             sig={:#x} compound={c:?}",
+                            std::str::from_utf8(tag),
+                            c.req,
+                            e.sig,
+                        );
+                        if !want && e.sig & c.req != c.req {
+                            filtered_out += 1;
+                        }
+                        checked += 1;
+                    }
+                }
+            }
+        }
+        // A filter that rejects nothing would pass the equality above trivially, so assert it is
+        // actually doing the work this change exists for.
+        assert!(checked > 10_000, "expected a real sweep, ran {checked}");
+        assert!(
+            filtered_out * 3 > checked,
+            "the filter rejected only {filtered_out}/{checked} pairs before any string compare"
+        );
+    }
+
+    /// The exact-comparison semantics the hash has to mirror: the TAG is case-insensitive, while `id`
+    /// and class tokens are case-SENSITIVE. Folding the wrong one of those is the false negative that
+    /// silently drops values, and it is invisible in any vector whose cases already agree.
+    #[test]
+    fn case_sensitivity_mirrors_the_predicates() {
+        let e = el(b"DIV", &[(b"class", "Foo"), (b"id", "Bar")]);
+        // mixed-case tag still matches, either way round
+        assert!(compound_matches(&cmp(Some("div"), Some("Bar"), &["Foo"]), &e));
+        assert!(compound_matches(&cmp(Some("DIV"), Some("Bar"), &["Foo"]), &e));
+        assert!(compound_matches(&cmp(Some("Div"), None, &[]), &e));
+        // wrong-case class / id still does NOT match
+        assert!(!compound_matches(&cmp(Some("DIV"), None, &["foo"]), &e));
+        assert!(!compound_matches(&cmp(Some("div"), None, &["FOO"]), &e));
+        assert!(!compound_matches(&cmp(Some("div"), Some("bar"), &[]), &e));
+        assert!(!compound_matches(&cmp(None, Some("BAR"), &[]), &e));
+        // and the signature itself must be what rejects the wrong-case cases (not just the string
+        // compare downstream) — otherwise the case rule could be wrong in the hash and never show
+        let wrong_class = cmp(Some("div"), None, &["foo"]);
+        let wrong_id = cmp(Some("div"), Some("bar"), &[]);
+        assert_ne!(e.sig & wrong_class.req, wrong_class.req);
+        assert_ne!(e.sig & wrong_id.req, wrong_id.req);
+        // the case-insensitive tag, in contrast, must NOT be rejected by the signature
+        let tag_only = cmp(Some("dIv"), None, &[]);
+        assert_eq!(e.sig & tag_only.req, tag_only.req);
+    }
+
+    /// `req` must come only from the compound's own positive tag/id/classes. `*` contributes nothing,
+    /// and neither do the parts of the compound whose semantics the filter cannot represent.
+    #[test]
+    fn req_covers_only_positive_identity() {
+        use crate::selector::AttrPred;
+        const ALL_ON: sig::Opts = sig::Opts { tag: true, class: true };
+        assert_eq!(cmp(None, None, &[]).req, 0);
+        assert_eq!(cmp(Some("*"), None, &[]).req, 0);
+        assert_ne!(cmp(Some("div"), None, &[]).req, 0);
+
+        // `:not(.x)` / `:is(.x)` / `[href^=/]` on a universal compound: nothing to require
+        let mut neg = cmp(Some("*"), None, &[]);
+        neg.negations.push(cmp(None, None, &["x"]));
+        assert_eq!(sig::compound_req(&neg, ALL_ON), 0);
+        let mut isg = cmp(Some("*"), None, &[]);
+        isg.is_groups.push(vec![cmp(None, None, &["x"]), cmp(None, None, &["y"])]);
+        assert_eq!(sig::compound_req(&isg, ALL_ON), 0);
+        let mut at = cmp(Some("*"), None, &[]);
+        at.attrs.push(AttrPred::Prefix("href".into(), "/".into()));
+        assert_eq!(sig::compound_req(&at, ALL_ON), 0);
+
+        // ...but a nested compound still gets its OWN req, for its own recursive call
+        let mut neg2 = cmp(Some("*"), None, &[]);
+        neg2.negations.push(cmp(None, None, &["x"]));
+        sig::set_req_for_test(&mut neg2);
+        assert_eq!(neg2.req, 0);
+        assert_ne!(neg2.negations[0].req, 0);
     }
 }

--- a/src/matcher/mod.rs
+++ b/src/matcher/mod.rs
@@ -32,6 +32,7 @@ mod decode;
 mod compile;
 mod deferred;
 mod matching;
+mod sig;
 
 use compile::{
     any_has, any_reverse, any_text_pred, deferrable_has, deferrable_reverse,
@@ -94,6 +95,17 @@ pub struct OpenElem<'a> {
     /// an open `<b>` but not an open `<em>`, and both are `tag::OTHER`.
     scid: u8,
     attrs: Vec<(&'a [u8], Cow<'a, str>)>, // only "interesting" attrs; value entity-decoded (lazy Cow)
+    /// This element's identity signature: the Bloom bits of its tag, `id`, and class tokens, built
+    /// once at open and ANDed against each compound's `req` before any string comparison (see [`sig`]).
+    /// 0 when the schema requires no bits at all (`!wants.any()`), which makes the test a no-op.
+    ///
+    /// INVARIANT: this is built from the MATERIALIZED `attrs`, which hold only the schema's
+    /// "interesting" set — so it can carry class/id bits only for a schema that asked for those
+    /// attributes. `collect_interesting` adds `class`/`id` whenever ANY compiled compound references
+    /// them, and a `req` can only carry class/id bits if some compound did, so whenever a `req` demands
+    /// them this signature was built from the same data. Materializing fewer attributes than the
+    /// compounds reference would turn this filter into silently dropped values.
+    pub(super) sig: u64,
     matched: u128, // bit k: this element is a subject match for member-selector k (≤128 members)
     matched_tree: u128, // OR of `matched` over this element and its open ancestors
     text_cols: u128, // flat output columns that want a text event directly under this element
@@ -128,22 +140,28 @@ pub struct OpenElem<'a> {
 }
 
 impl<'a> OpenElem<'a> {
-    /// A bare element for matching-kernel tests: a tag, no attributes, no bookkeeping. Only the
-    /// `matching` unit tests build elements directly; the scan always goes through `start_tag`.
-    #[cfg(test)]
-    pub(super) fn for_test(tag: &'a [u8]) -> Self {
-        OpenElem {
+    /// A freshly opened element: the tokenizer's facts, plus the signature DERIVED from the
+    /// materialized `attrs`. The only constructor — the scan and the unit-test builders both go through
+    /// it, so a derived field cannot be set at one site and forgotten at the other. `wants` is what the
+    /// schema's compounds require (see [`sig::Wants`]); when they require nothing, every `req` is 0 and
+    /// the signature would filter nothing, so it isn't built.
+    fn open(
+        tag: &'a [u8], tid: u8, scid: u8, attrs: Vec<(&'a [u8], Cow<'a, str>)>, start: usize,
+        wants: sig::Wants,
+    ) -> Self {
+        let mut e = OpenElem {
             tag,
-            tid: 0,
-            scid: 0,
-            attrs: Vec::new(),
+            tid,
+            scid,
+            attrs,
+            sig: 0,
             matched: 0,
             matched_tree: 0,
             text_cols: 0,
             seen: 0,
             prev: 0,
             anchor: 0,
-            start: 0,
+            start,
             cap_cols: 0,
             insts: 0,
             gcaps: Vec::new(),
@@ -158,7 +176,53 @@ impl<'a> OpenElem<'a> {
             txt_subj: 0,
             txt_states: Vec::new(),
             txt_emit: Vec::new(),
+        };
+        if wants.any() {
+            e.sig = e.signature(wants);
         }
+        e
+    }
+
+    /// This element's Bloom signature, over exactly the sources `compound_matches` compares
+    /// positively — and only the KINDS of source some compound requires (see [`sig::Wants`]: a schema
+    /// with no class-led compound must not pay to hash every element's class list).
+    ///
+    /// Built through the element's OWN accessors (`attr`, `each_class`) rather than by re-reading
+    /// `attrs`, so "which `id`, which `class` attribute, which tokens" cannot answer differently here
+    /// than in the predicate the filter guards — including for markup that repeats the attribute, where
+    /// both sides take the first.
+    fn signature(&self, wants: sig::Wants) -> u64 {
+        let mut s = if wants.tag { sig::tag_bits(self.tag) } else { 0 };
+        if wants.id {
+            if let Some(id) = self.attr("id") {
+                s |= sig::id_bits(id.as_bytes());
+            }
+        }
+        if wants.class {
+            self.each_class(|cls| s |= sig::class_bits(cls.as_bytes()));
+        }
+        s
+    }
+
+    /// A bare element for matching-kernel tests: a tag, no attributes, no bookkeeping. Only the
+    /// `matching` unit tests build elements directly; the scan always goes through `start_tag`.
+    #[cfg(test)]
+    pub(super) fn for_test(tag: &'a [u8]) -> Self {
+        Self::open(tag, 0, 0, Vec::new(), 0, sig::Wants::all())
+    }
+
+    /// A test element WITH attributes (`&'static str` values, borrowed like the scan's clean-UTF-8
+    /// case), so the class/id-dependent predicates and the signature can be exercised directly.
+    #[cfg(test)]
+    pub(super) fn for_test_attrs(tag: &'a [u8], attrs: &[(&'a [u8], &'a str)]) -> Self {
+        Self::open(
+            tag,
+            0,
+            0,
+            attrs.iter().map(|&(n, v)| (n, Cow::Borrowed(v))).collect(),
+            0,
+            sig::Wants::all(),
+        )
     }
 
     pub(super) fn attr(&self, name: &str) -> Option<&str> {
@@ -169,6 +233,12 @@ impl<'a> OpenElem<'a> {
     }
     pub(super) fn has_class(&self, cls: &str) -> bool {
         self.attr("class").is_some_and(|v| v.split_whitespace().any(|t| t == cls))
+    }
+    /// Every `class=` token of this element, in source order — what [`Self::signature`] needs, as
+    /// opposed to `has_class`'s membership test. Both read `attr("class")` and split it the same way, so
+    /// the tokens the signature hashes are exactly the tokens the predicate compares.
+    fn each_class(&self, f: impl FnMut(&str)) {
+        self.attr("class").into_iter().flat_map(str::split_whitespace).for_each(f);
     }
 }
 
@@ -498,6 +568,11 @@ pub struct CompiledSchema {
     // deferred (preceding-sibling-predicate) boundary fires only at its `C`'s close, not at open. All
     // ones when no Case-B selector is compiled — the hot sibling path is then unchanged.
     trig_immediate_mask: u64,
+    // What the compiled compounds require of an element signature (see `sig::Wants`) — derived by the
+    // same walk that fills the `req`s, so the two cannot disagree. That is the whole safety argument
+    // for letting the scan build LESS than a full signature: a kind of bit no `req` asks for can be
+    // left out, but one that is asked for must always be present.
+    wants: sig::Wants,
 }
 
 /// Per-page scan state, borrowing a compiled [`CompiledSchema`] and the document bytes. One is built,
@@ -924,6 +999,58 @@ impl CompiledSchema {
         let has_ns_element = entries
             .iter()
             .any(|cs| matches!(&cs.terminal, Terminal::NormalizeSpace(inner) if matches!(**inner, Terminal::OuterHtml)));
+
+        // Signature requirements (see `sig`): ONE pass over every tier that holds compiled compounds,
+        // filling each `Compound::req` and accumulating what the scan must build (`sig::Wants`). Both
+        // jobs in the same walk on purpose — a tier missing here keeps `req == 0` (its filter is a
+        // no-op) and adds nothing to `wants`, so an omission costs speed and can never drop a match.
+        // Tail schemas are themselves `CompiledSchema`s, already finalized by their own `compile` call.
+        fn seg_reqs(seg: &mut Segment, o: sig::Opts, w: &mut sig::Wants) {
+            for c in &mut seg.parts {
+                sig::set_req(c, o, w);
+            }
+        }
+        // Are tag / class bits worth their per-element hash for THIS schema (see `sig::BITS_MIN`)? The
+        // count is over the source selectors, which is a superset of what compiles — a cost estimate,
+        // not a correctness input: `opts` drives the element signature and every `req` alike, so a
+        // miscount can only buy or forgo the optimization.
+        let (tag_tests, class_tests) = queries
+            .iter()
+            .flatten()
+            .chain(groups.iter().flat_map(|(c, subs)| c.iter().chain(subs.iter().flatten())))
+            .flat_map(|sel| sel.parts.iter())
+            .map(sig::tests)
+            .fold((0, 0), |(t, c), (dt, dc)| (t + dt, c + dc));
+        let opts = sig::Opts {
+            tag: tag_tests >= sig::BITS_MIN,
+            class: class_tests >= sig::BITS_MIN,
+        };
+        let mut wants = sig::Wants::default();
+        for cs in &mut entries {
+            for seg in &mut cs.segments {
+                seg_reqs(seg, opts, &mut wants);
+            }
+        }
+        for g in &mut group_specs {
+            for sub in &mut g.subs {
+                if let Some(seg) = &mut sub.seg {
+                    seg_reqs(seg, opts, &mut wants);
+                }
+            }
+        }
+        for re in &mut reverse_entries {
+            seg_reqs(&mut re.seg, opts, &mut wants);
+        }
+        for he in &mut has_entries {
+            seg_reqs(&mut he.seg, opts, &mut wants);
+            // the `:has()` inner compound is matched by its own `compound_matches` call, against
+            // descendants, so it is a filterable question in its own right
+            sig::set_req(&mut he.has.inner, opts, &mut wants);
+        }
+        for te in &mut text_entries {
+            seg_reqs(&mut te.seg, opts, &mut wants);
+        }
+
         CompiledSchema {
             n_flat_cols: queries.len(),
             n_groups: group_specs.len(),
@@ -945,6 +1072,7 @@ impl CompiledSchema {
             text_entries,
             tail_schemas,
             trig_immediate_mask,
+            wants,
         }
     }
 
@@ -1740,33 +1868,18 @@ impl<'a> TokenSink<'a> for Matcher<'a> {
                 attrs.push((an, decode_attr(av, self.enc)));
             }
         }
-        self.stack.push(OpenElem {
-            tag: name,
+        // The element's signature is built from the MATERIALIZED attributes only. That is sound because
+        // `collect_interesting` adds `class`/`id` to the interesting set whenever any compiled compound
+        // references them, so a `req` carrying class/id bits implies this element's `sig` saw the same
+        // attributes; a schema referencing neither leaves both at 0 and the filter idle.
+        self.stack.push(OpenElem::open(
+            name,
             tid,
             scid,
             attrs,
-            matched: 0,
-            matched_tree: 0,
-            text_cols: 0,
-            seen: 0,
-            prev: 0,
-            anchor: 0,
-            start: span_start,
-            cap_cols: 0,
-            insts: 0,
-            gcaps: Vec::new(),
-            child_index: 0,
-            of_type_index: 0,
-            rev_subj: 0,
-            rev_buf: Vec::new(),
-            rev_pending: Vec::new(),
-            has_subj: 0,
-            has_done: 0,
-            has_buf: Vec::new(),
-            txt_subj: 0,
-            txt_states: Vec::new(),
-            txt_emit: Vec::new(),
-        });
+            span_start,
+            self.schema.wants,
+        ));
         let top = self.stack.len() - 1;
         // Assign this element's 1-based sibling positions from its parent's running counts, BEFORE
         // `eval` (positional compounds read them). Only when the schema uses positions.
@@ -2062,5 +2175,103 @@ mod deferred_state_tests {
         assert!(state.holds(&pred));
         state.update(&pred, "!", false);
         assert!(!state.holds(&pred));
+    }
+}
+
+#[cfg(test)]
+mod sig_wants_tests {
+    use super::*;
+
+    fn wants(queries: &[&str]) -> sig::Wants {
+        let members: Vec<Vec<Selector>> =
+            queries.iter().map(|q| crate::selector::parse_list(q)).collect();
+        CompiledSchema::compile(&members, &[]).wants
+    }
+
+    /// `wants` decides how much of an element signature the scan builds, so it must be live for the
+    /// schemas that can use one and idle for the schemas that cannot. It is derived from the same walk
+    /// that sets the `req`s, so this also witnesses that the walk reaches each tier: a tier it skipped
+    /// would leave a schema that clearly requires bits reporting nothing wanted.
+    #[test]
+    fn wants_is_live_exactly_when_some_compound_requires_bits() {
+        assert!(wants(&[".price::text", ".title::text"]).any());
+        assert!(wants(&["div::text", "p::text"]).any());
+        assert!(wants(&["#main a::attr(href)"]).any());
+        assert!(wants(&["li.card:last-child span.price::text"]).any()); // deferred reverse tier
+        assert!(wants(&["div.box:has(a.deep)::text"]).any()); // deferred `:has` tier
+        // a universal selector requires nothing, so the whole signature machinery stays off
+        assert!(!wants(&["*::text"]).any());
+        assert!(!wants(&["::text"]).any());
+        assert!(!wants(&[]).any());
+    }
+
+    /// The per-KIND flags are the licence to leave bits out of an element's signature, so each must be
+    /// set whenever ANY compound — including one nested in `:not()`/`:is()`, or a `:has()` inner, or a
+    /// grouped sub-field — could ask `has_class`/`attr("id")` about it. A flag that is off while some
+    /// `req` carries that kind of bit is the one way this filter drops a value. Cases meant to be ON
+    /// carry two tests of their kind, so `sig::BITS_MIN` isn't what they measure — the two cases that DO
+    /// measure it say so.
+    #[test]
+    fn per_kind_flags_cover_every_compound_that_asks() {
+        assert!(!wants(&["div::text", "p::text"]).class);
+        assert!(!wants(&["div::text", "p::text"]).id);
+        assert!(wants(&["div::text", "p::text"]).tag);
+        // one test of a kind can't amortize hashing it (`sig::BITS_MIN`), so that kind stays off
+        assert!(!wants(&["div::text"]).tag);
+        assert!(!wants(&[".price::text"]).class);
+        assert!(wants(&[".price::text", ".title::text"]).class);
+        assert!(wants(&["#main::text"]).id);
+        assert!(wants(&["div:not(.skip).x::text"]).class); // negated class: still asked at match time
+        assert!(wants(&["div:is(.a, .b)::text"]).class);
+        assert!(wants(&["div:not(#skip)::text"]).id);
+        assert!(wants(&["div.x:has(.deep)::text"]).class); // `:has` inner, matched against descendants
+        assert!(wants(&["li:last-child.price.sale::text"]).class); // deferred reverse tier
+    }
+
+    /// The class bits are a COST trade (`sig::BITS_MIN`), and turning them off must turn them off
+    /// on BOTH sides — that is the whole reason it is sound. So a schema below the threshold must report
+    /// `class == false` AND leave every compiled `req` free of class bits; if the two ever disagreed, the
+    /// class-led compound would be filtered against a signature that never saw a class.
+    #[test]
+    fn below_the_cost_threshold_class_bits_leave_both_sides() {
+        let one = CompiledSchema::compile(&[crate::selector::parse_list(".price::text")], &[]);
+        assert!(!one.wants.class);
+        assert_eq!(one.entries[0].segments[0].parts[0].req, 0, "req kept class bits the sig lacks");
+        // the same compound in a schema that asks about classes twice: bits on, on both sides
+        let two = CompiledSchema::compile(
+            &[crate::selector::parse_list(".price::text"), crate::selector::parse_list(".title::text")],
+            &[],
+        );
+        assert!(two.wants.class);
+        assert_ne!(two.entries[0].segments[0].parts[0].req, 0);
+    }
+
+    /// A deferred entry whose value comes from a DESCENDANT splits into a prefix (matched in the main
+    /// scan) and a TAIL sub-schema (run over the winner's span). The class-led part of
+    /// `li:last-child span.price.sale::text` lives in the tail, so the main schema legitimately wants no
+    /// class bits — but the tail must want them, since it is the schema whose compounds ask `has_class`.
+    /// Each tail is compiled in its own right, which is what makes that automatic.
+    #[test]
+    fn a_deferred_tail_carries_its_own_wants() {
+        let members = crate::selector::parse_list("li:last-child span.price.sale::text");
+        let schema = CompiledSchema::compile(&[members], &[]);
+        assert!(schema.wants.any() && !schema.wants.class, "prefix is `li:last-child`, no class");
+        let tail = &schema.tail_schemas[0].schema;
+        assert!(tail.wants.class, "the tail's `.price.sale` compound would never be filtered");
+        assert_ne!(tail.entries[0].segments[0].parts[0].req, 0);
+    }
+
+    /// Grouped containers and sub-fields are their own tier; a sub-field's compounds are matched by the
+    /// same `compound_matches`, so they must be walked too.
+    #[test]
+    fn grouped_tier_is_walked() {
+        let subs = vec![Some(crate::selector::parse_list(".price::text").remove(0))];
+        let container = Some(crate::selector::parse_list("div.card").remove(0));
+        let schema = CompiledSchema::compile(&[], &[(container, subs)]);
+        assert!(schema.wants.any());
+        assert!(schema.wants.class, "a grouped sub-field's class token was not accounted for");
+        let sub_seg = schema.groups[0].subs[0].seg.as_ref().expect("single-segment sub");
+        assert_ne!(sub_seg.parts[0].req, 0, "sub-field compound never got its req");
+        assert_ne!(schema.entries[0].segments[0].parts[0].req, 0, "container never got its req");
     }
 }

--- a/src/matcher/sig.rs
+++ b/src/matcher/sig.rs
@@ -1,0 +1,232 @@
+//! One-sided 64-bit signatures: a Bloom filter that lets the matcher reject most (element, compound)
+//! pairs before it touches a single string. The shape is WebKit/Blink's `SelectorFilter`, narrowed to
+//! this engine's kernel.
+//!
+//! Every start tag builds a signature from the three things a compound can require *positively* — its
+//! tag name, its `id`, and each of its `class` tokens — mapping each to TWO bit positions and ORing
+//! them in. Each compiled compound gets a `req` built by the same hash over the same three sources. A
+//! compound whose `req` has a bit the element lacks cannot match, so `compound_matches` opens with one
+//! AND and one compare (see [`super::matching::compound_matches`]).
+//!
+//! # The two rules this file exists to hold
+//!
+//! **One-sided.** A set bit is NECESSARY, never sufficient: hash collisions and the OR make false
+//! POSITIVES normal (a `req` can be satisfied by bits from unrelated tokens), and they cost only the
+//! exact comparisons that always ran. A false NEGATIVE is a silently dropped value — the one outcome
+//! this engine's no-fallback contract cannot absorb. So the filter may only ever turn a `false` into a
+//! faster `false`, and this module never gets to answer `true`.
+//!
+//! **The hash mirrors the comparison it guards.** `compound_matches` tests the tag with
+//! `eq_ignore_ascii_case` but the id and class tokens with `==`, so tag bytes are ASCII-folded on BOTH
+//! sides and id/class bytes are hashed verbatim on both. Folding a token whose comparison is
+//! case-sensitive (or not folding one whose comparison isn't) would produce exactly the false negative
+//! above: `<div class="Foo">` would stop matching `.Foo`.
+//!
+//! Each source also gets its own hash basis, so a class named `header` does not satisfy a `header` tag
+//! requirement. That is a selectivity choice, not a correctness one — sharing a basis would only cost
+//! wasted exact comparisons.
+//!
+//! Signatures are built per START TAG, so each *kind* of bit has to earn that cost for the schema at
+//! hand; a kind the schema barely uses is dropped from the element side and the `req` side together
+//! ([`Opts`], [`BITS_MIN`]). Dropping a kind can only make the filter weaker, never wrong — but only
+//! because ONE decision drives both sides.
+//!
+//! # Not done here
+//!
+//! This filters a compound against ONE element. An **ancestor** signature — the OR of the signatures of
+//! an element and its open ancestors, the same shape as `OpenElem::matched_tree` — would let
+//! `div.foo a` reject at the subject, before `seg_match_anchored`'s `O(depth × compounds)` walk. It is a
+//! separate change with its own measurement (the ancestor OR has to be maintained per open element, and
+//! the walk it skips is only reached by multi-compound selectors), deliberately not folded in here.
+
+use crate::selector::Compound;
+
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+const FNV_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+// Per-source bases (FNV's basis, perturbed) keep the three kinds in separate hash spaces.
+const BASIS_TAG: u64 = FNV_BASIS;
+const BASIS_ID: u64 = FNV_BASIS ^ 0x9e37_79b9_7f4a_7c15;
+const BASIS_CLASS: u64 = FNV_BASIS ^ 0xc2b2_ae3d_27d4_eb4f;
+
+/// FNV-1a over `bytes`, ASCII-lowercasing as it goes when `fold`. Folding must match the guarded
+/// predicate exactly: `eq_ignore_ascii_case` folds only ASCII, and so does `to_ascii_lowercase` here —
+/// a non-ASCII byte hashes verbatim on both sides.
+///
+/// This runs over every class token of every element, so the byte-at-a-time multiply chain is a fair
+/// thing to suspect. An eight-bytes-per-multiply variant (word load + a whole-word `| 0x20` fold) was
+/// tried and measured NO faster on the class-heavy benchmark — the short-token case pays a
+/// variable-length copy to build each word — so the simple form stays.
+fn digest(basis: u64, bytes: &[u8], fold: bool) -> u64 {
+    let mut h = basis;
+    for &b in bytes {
+        let b = if fold { b.to_ascii_lowercase() } else { b };
+        h = (h ^ b as u64).wrapping_mul(FNV_PRIME);
+    }
+    h
+}
+
+/// The two bits a token claims. FNV-1a's low bits are not independent enough to slice twice, so the
+/// digest gets a finalizing mix first; the two 6-bit picks are then effectively independent, which is
+/// what makes a 64-bit filter with `k = 2` worth more than one with `k = 1`.
+fn bits(h: u64) -> u64 {
+    let mut m = h;
+    m ^= m >> 33;
+    m = m.wrapping_mul(0xff51_afd7_ed55_8ccd);
+    m ^= m >> 33;
+    (1u64 << (m & 63)) | (1u64 << ((m >> 6) & 63))
+}
+
+/// Bits for an element or compound TAG NAME — ASCII-folded (`eq_ignore_ascii_case`).
+pub(super) fn tag_bits(tag: &[u8]) -> u64 {
+    bits(digest(BASIS_TAG, tag, true))
+}
+
+/// Bits for an `id` value — verbatim (`compound_matches` compares ids with `==`).
+pub(super) fn id_bits(id: &[u8]) -> u64 {
+    bits(digest(BASIS_ID, id, false))
+}
+
+/// Bits for one `class` token — verbatim (`has_class` compares tokens with `==`).
+pub(super) fn class_bits(cls: &[u8]) -> u64 {
+    bits(digest(BASIS_CLASS, cls, false))
+}
+
+/// The signature bits compound `c` REQUIRES of an element, from its own positive tag/id/classes.
+///
+/// Everything else on the compound contributes nothing, and each omission is load-bearing:
+///   * `tag == None`/`"*"` — the universal selector requires no tag;
+///   * `negations` — a `:not(.x)` requirement is INVERTED; requiring `.x`'s bits would reject exactly
+///     the elements that match;
+///   * `is_groups` — `:is(a, b)` is an OR, so no single alternative is required (their own `req`s are
+///     set for when `compound_matches` recurses into them, where each IS the whole question);
+///   * `attrs` — `[href^="/"]` is a substring/prefix test, not the token equality the hash models
+///     (and `[class~=x]`/`[id=x]` go through the generic attribute path, whose value the signature
+///     does not summarize);
+///   * `positional`/`reverse`/`has`/`text_pred` — not element-identity at all.
+pub(super) fn compound_req(c: &Compound, o: Opts) -> u64 {
+    let mut req = 0u64;
+    if let (true, Some(t)) = (o.tag, c.tag.as_deref().filter(|t| *t != "*")) {
+        req |= tag_bits(t.as_bytes());
+    }
+    if let Some(id) = &c.id {
+        req |= id_bits(id.as_bytes());
+    }
+    if o.class {
+        for cl in &c.classes {
+            req |= class_bits(cl.as_bytes());
+        }
+    }
+    req
+}
+
+/// Which KINDS of bit a schema's signatures use. Applied to both sides — the element signature and
+/// every `req` — which is what keeps a disabled kind sound: if no `req` carries class bits, an element
+/// signature without class bits cannot fail to satisfy one. Soundness therefore does not depend on the
+/// cost estimate below being right, only on ONE decision driving both sides.
+#[derive(Clone, Copy)]
+pub(super) struct Opts {
+    pub tag: bool,
+    pub class: bool,
+}
+
+/// Every element hashes its own tag/class into its signature whether or not any compound turns out to
+/// want them, so each KIND of bit has to earn that per-element cost — and a schema that performs a
+/// single test of some kind cannot: the filter would trade a hash for at most one comparison. Below the
+/// threshold the bits leave BOTH sides, which is sound for the reason in [`Opts`] and leaves the filter
+/// working on whatever kinds remain (or idle, if none do — indistinguishable from before this existed).
+///
+/// Measured on the class-heavy benchmark (`tools/bench_matrix.py --class-led`, one class-led field per
+/// count): with class bits unconditional, 1 field was ~11% SLOWER, 2 were ~4% faster, 4 ~18%, 32 ~64%.
+/// Tag bits the same shape but smaller, being one short bounded string rather than a token list: 1
+/// tag-led field ~3.5% slower, 8 ~3.5% faster, 32 ~28%. Two is where each starts paying.
+pub(super) const BITS_MIN: usize = 2;
+
+/// `id` has no threshold: it is one bounded `attrs` lookup and one hash of one value, and a schema that
+/// names an id is asking about a near-unique attribute — the filter's best case. The costly kinds are
+/// the ones counted below.
+///
+/// How many tag / class-membership tests this compound performs, counting the nested compounds that get
+/// their own `compound_matches` call. Feeds the [`BITS_MIN`] decision, which is a COST estimate:
+/// over- or under-counting can only buy or forgo the optimization, never change a match (see [`Opts`]).
+pub(super) fn tests(c: &Compound) -> (usize, usize) {
+    let mut tag = usize::from(c.tag.as_deref().is_some_and(|t| t != "*"));
+    let mut class = c.classes.len();
+    let nested = c
+        .negations
+        .iter()
+        .chain(c.is_groups.iter().flatten())
+        .chain(c.has.as_ref().map(|h| &*h.inner));
+    for n in nested {
+        let (t, cl) = tests(n);
+        tag += t;
+        class += cl;
+    }
+    (tag, class)
+}
+
+/// What a compiled schema's compounds actually require of an element, accumulated by the same walk
+/// that fills their `req`s ([`set_req`]).
+///
+/// Each flag OFF licenses the scan to skip building that part of the element signature, and the licence
+/// is sound because the flag and the `req`s come out of ONE walk under one [`Opts`]: a flag is off
+/// exactly when no `req` carries that kind of bit, so leaving those bits out of an element's signature
+/// cannot make a `req` unsatisfiable. What would break it is a second, separately-derived answer to
+/// "does this schema use classes?" — then the element side and the `req` side could disagree.
+///
+/// The flags are worth having because the work is per START TAG: class bits are `O(class tokens)` of
+/// hashing, tag bits one short hash, id bits an `attrs` lookup — all wasted on a schema whose compounds
+/// never ask.
+#[derive(Clone, Copy, Default)]
+pub(super) struct Wants {
+    mask: u64,         // OR of every compiled `req`
+    pub tag: bool,     // some compound names a concrete tag (and tag bits are enabled)
+    pub class: bool,   // some compound carries a class token, so `has_class` will be asked
+    pub id: bool,      // some compound carries an id
+}
+
+impl Wants {
+    /// Does any compound require any bit? If not, every `req` is 0 and the whole filter is a no-op, so
+    /// the scan can skip signatures entirely.
+    pub(super) fn any(&self) -> bool {
+        self.mask != 0
+    }
+
+    /// Build every kind of bit — what the matching-kernel unit tests use, so their elements carry the
+    /// most selective signature any schema could ask for (the strictest test of one-sidedness).
+    #[cfg(test)]
+    pub(super) fn all() -> Wants {
+        Wants { mask: u64::MAX, tag: true, class: true, id: true }
+    }
+}
+
+/// [`set_req`] for the kernel unit tests, which build compounds one at a time and get their elements'
+/// signatures from [`Wants::all`] rather than from a compiled schema.
+#[cfg(test)]
+pub(super) fn set_req_for_test(c: &mut Compound) {
+    set_req(c, Opts { tag: true, class: true }, &mut Wants::default());
+}
+
+/// Fill in `c.req` and the `req` of every compound nested inside it (`:not(...)` args and
+/// `:is(...)`/`:where(...)` alternatives are matched by their own `compound_matches` call, so each is
+/// its own filterable question), accumulating what the scan must build into `w`.
+///
+/// Setting the reqs and accumulating `w` in ONE walk is deliberate: a compound this pass never reaches
+/// keeps `req == 0` (the filter is a no-op for it) *and* contributes nothing to `w`, so forgetting one
+/// can only cost speed. `w` must never be re-derived from anything but the reqs actually set here —
+/// that is the one way this filter turns into dropped values. (`o` is different in kind: a cost estimate
+/// the caller may compute however it likes, because it constrains BOTH sides equally.)
+pub(super) fn set_req(c: &mut Compound, o: Opts, w: &mut Wants) {
+    c.req = compound_req(c, o);
+    w.mask |= c.req;
+    w.tag |= o.tag && c.tag.as_deref().is_some_and(|t| t != "*");
+    w.class |= o.class && !c.classes.is_empty();
+    w.id |= c.id.is_some();
+    for neg in &mut c.negations {
+        set_req(neg, o, w);
+    }
+    for group in &mut c.is_groups {
+        for alt in group {
+            set_req(alt, o, w);
+        }
+    }
+}

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -95,6 +95,10 @@ pub struct Compound {
     // alternative compounds; the element must match ≥1 alternative in EVERY group (OR within a group,
     // AND across groups). Decided at open like `:not`, so no deferral. Empty = no `:is`/`:where`.
     pub is_groups: Vec<Vec<Compound>>,
+    /// DERIVED, not parsed: the signature bits an element must carry for this compound to have a
+    /// chance (see `matcher::sig`). The parser leaves it 0; the matcher's compile step fills it in.
+    /// 0 always means "filter nothing", so a compound that never reaches that step is merely slower.
+    pub req: u64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/tools/bench_matrix.py
+++ b/tools/bench_matrix.py
@@ -37,13 +37,33 @@ SMOKE = False
 # Deferred-TAIL selectors: their values come from a re-scan of each winner's span rather than the
 # streaming pass (see docs/DESIGN.md), so each one costs its own extra pass over the matched subtrees and
 # they do NOT share the scan the way pool selectors do. Measured on an 800-card page: one tail field is
-# ~2.1x a plain field and eight are ~4.2x, i.e. the cost grows with FIELD COUNT. Kept as a separate pool
+# ~2.6x a plain field and eight are ~4.2x, i.e. the cost grows with FIELD COUNT. Kept as a separate pool
 # so that stays visible instead of being invisible in the headline numbers.
 TAIL_POOL = [
     "div:has(a) a::attr(href)", "div:has(a) p::text", ".product:has(img) .price::text",
     ".product:has(a) .title::text", "div:has(p) a::text", ".product:has(.price) img::attr(src)",
     "li:last-child a::attr(href)", "div:has(a) ::text",
 ]
+
+# CLASS-LED, high field count — the regime where the matcher's per-(element, selector) STRING work
+# dominates: every class-led compound asks the element for its `class=` and looks for its own token,
+# so a utility-CSS page (many class tokens per element) times that work N_selectors x N_elements.
+# The tag-led POOL above barely exercises it (a tag test is one memcmp), so a matcher change that
+# targets class/id comparison is invisible there — this table is the one that can show it, in either
+# direction. Most fields deliberately DON'T match: a real schema is written for one site's template
+# and its misses still cost a test per element.
+CLASS_POOL = [
+    ".price::text", ".title::text", ".desc::text", ".thumb::attr(src)", ".link::attr(href)",
+    ".card .price::text", ".card .title::text", ".product-card .desc::text",
+    ".badge::text", ".rating::text", ".sku::text", ".stock-label::text",
+    ".card .badge .value::text", ".breadcrumb a::attr(href)", ".pagination .next::attr(href)",
+    ".facet .label::text", ".swatch::attr(data-color)", ".promo .text-xl::text",
+    ".review .author::text", ".review .body::text", ".seller-name::text", ".shipping-note::text",
+    ".card .price-was::text", ".card .price-now::text", ".gallery img::attr(src)",
+    ".spec-table .name::text", ".spec-table .value::text", ".qty-input::attr(value)",
+    ".wishlist::attr(href)", ".compare::attr(href)", ".variant .title::text", ".tag-list a::text",
+]
+CLASS_COUNTS = [4, 8, 16, 32]
 
 
 # ---- page generators (deterministic, ~size bytes) ----
@@ -73,6 +93,24 @@ def table(size):
     while n < size:
         body.append(row); n += len(row)
     return f'<!DOCTYPE html><html><head><title>Data</title></head><body><table><tbody>{"".join(body)}</tbody></table></body></html>'.encode()
+
+
+def class_heavy(size):
+    """Utility-CSS markup: every element carries a handful of class tokens (the shape Tailwind-style
+    sites produce), so a class-led selector's token search is real work rather than a 1-token hit."""
+    card = ('<div class="card product-card flex flex-col rounded-lg shadow-sm p-4 mb-2">'
+            '<h3 class="title text-lg font-semibold leading-tight truncate">Widget Pro</h3>'
+            '<span class="price text-xl font-bold text-green-700">$19.99</span>'
+            '<a class="link btn btn-primary inline-block mt-2" href="/p/123">view</a>'
+            '<img class="thumb rounded object-cover w-full" src="/img/w.jpg" alt="w">'
+            '<p class="desc text-sm text-gray-600 leading-snug">A useful widget for many tasks.</p>'
+            '</div>')
+    body, n = [], 0
+    while n < size:
+        body.append(card); n += len(card)
+    return ('<!DOCTYPE html><html><head><title>Shop</title></head>'
+            f'<body><div class="grid grid-cols-3 gap-4 px-6">{"".join(body)}</div>'
+            '</body></html>').encode()
 
 
 def deep_nested(size):
@@ -145,24 +183,50 @@ def parsel_bench(html_bytes, sels):
     return (time.perf_counter() - t) / iters * 1e6
 
 
-def run_table(name, html_bytes, counts=COUNTS):
+def run_table(name, html_bytes, counts=COUNTS, pool=None, engine_only=False):
+    pool = pool or POOL
     kb = len(html_bytes) / 1024
     print(f"\n### {name}  ({kb:.0f} KB)")
-    print(f"  {'sels':>4} | {'engine µs':>10} {'MB/s':>7} {'vals':>6} | {'parsel µs':>10} | {'speedup':>7}")
-    print("  " + "-" * 60)
+    cols = f"  {'sels':>4} | {'engine µs':>10} {'MB/s':>7} {'vals':>6}"
+    print(cols if engine_only else f"{cols} | {'parsel µs':>10} | {'speedup':>7}")
+    print("  " + "-" * (34 if engine_only else 60))
     for c in counts:
-        sels = POOL[:c]
+        sels = pool[:c]
         eus, embs, vals = engine_bench(html_bytes, sels)
+        row = f"  {c:>4} | {eus:>10.1f} {embs:>7.0f} {vals:>6}"
+        if engine_only:
+            print(row)
+            continue
         pus = parsel_bench(html_bytes, sels)
-        print(f"  {c:>4} | {eus:>10.1f} {embs:>7.0f} {vals:>6} | {pus:>10.1f} | {pus/eus:>6.1f}x")
+        print(f"{row} | {pus:>10.1f} | {pus/eus:>6.1f}x")
+
+
+def class_led_table():
+    """The class-led, high-field-count sweep — see CLASS_POOL. Also runs the tag-led POOL over the same
+    page, so a matcher change's effect on class work can be read against its effect on tag work. That
+    contrast is engine-vs-engine, so it skips Parsel (which costs minutes per cell at 32 selectors)."""
+    html = class_heavy(200_000)
+    run_table("class-led — utility-CSS page, N class selectors", html, CLASS_COUNTS, CLASS_POOL)
+    run_table(
+        "class-led page, tag-led selectors (same page, engine only, for contrast)",
+        html, CLASS_COUNTS, POOL, engine_only=True,
+    )
 
 
 def main():
     global SMOKE
     ap = argparse.ArgumentParser()
     ap.add_argument("--smoke", action="store_true", help="quick article/deep check at 8 and 32 selectors")
+    ap.add_argument("--class-led", action="store_true",
+                    help="only the class-led high-field-count table (the matcher string-work regime)")
     args = ap.parse_args()
     SMOKE = args.smoke
+    if args.class_led:
+        print("=" * 64)
+        print("CLASS-LED SCHEMA x FIELD COUNT  (engine vs Parsel, µs/page)")
+        print("=" * 64)
+        class_led_table()
+        return
     med = 200_000
     pages = (
         [("article (text-heavy)", article(med)), ("deep-nested", deep_nested(med))]
@@ -188,6 +252,8 @@ def main():
 
     if args.smoke:
         return
+
+    class_led_table()
 
     # grouped (Many/One): one `.product` container × {1,3,5} subs vs Parsel's per-container loop.
     # This measures the single-pass per-instance × per-sub on-demand evaluation the grouped path adds.


### PR DESCRIPTION
> **Stacked PR.** The base is `selector-and-tree-rule-hardening`, not `main` — that branch holds the
> earlier unmerged commits from this line of work, and pointing at it keeps this diff to the one commit
> under review. The base is still moving; new commits on it won't widen this diff (GitHub diffs from the
> merge base), but this branch will need a rebase onto it before merging. Land the base first, or
> retarget this to `main` once it does.

## What

Adds a **one-sided element/compound Bloom signature** (`src/matcher/sig.rs`) to the matcher's hot path. At each start tag an element hashes its tag name, `id` and every `class` token to two bits each of a `u64`; each compiled compound carries the same bits for its own positive tag/id/classes; `compound_matches` now opens with:

```rust
if el.sig & c.req != c.req { return false; }
```

One AND and one compare reject most `(element, selector)` pairs before any string is touched. A pair that survives falls through to today's exact comparisons unchanged.

**This is a pure performance change: no extracted value changes.** The matcher's cost is `selectors × elements`, and every pair used to pay string work — an `eq_ignore_ascii_case` per tag test, and per class test an `attrs` scan plus a fresh `split_whitespace` of `class=`. An element with a 6-token class list under 20 class-led selectors re-split that attribute 20 times.

## Why it's safe

Three properties carry it, and each is a hinge rather than a detail:

- **One-sided, structurally.** A set bit is *necessary, never sufficient*. Collisions make false **positives** normal — they cost only the comparisons that always ran — while a false negative would be a silently dropped value, which the no-fallback contract cannot absorb. The shipped path and the test oracle are **one** predicate parameterised by a const generic, differing only in whether the pre-filter runs, so they cannot drift.
- **The hash mirrors the predicate it guards.** Tags compare with `eq_ignore_ascii_case`, so they fold on both sides; `id` and class tokens compare with `==`, so they hash verbatim. Getting that backwards drops values and is invisible to any vector whose cases already agree. Nothing is contributed by `:not()` (inverted), `:is()` (an OR), attribute predicates, or positions.
- **One walk** fills every `req` *and* derives what the scan must build. A tier the walk misses keeps `req == 0` — slower, never wrong — and contributes nothing to the flags, so the two cannot disagree. That is also what makes it safe to build *less* than a full signature: a kind of bit no `req` asks for may be left out.

The subtle hinge called out in both places it depends on: the element signature is built from **materialized** attributes only, and `collect_interesting` guarantees `class`/`id` are materialized whenever any compound references them.

## Measurement

Both builds interleaved **inside each cell**, min-of-3. Sequential runs on this machine drift 5–10%, which is enough to invent a result — an eight-bytes-per-multiply hash "measured" 2–6% slower across cells where hashing barely runs, all of it drift.

| workload (196 KB page) | 1 field | 2 | 4 | 8 | 16 | 32 |
| --- | --- | --- | --- | --- | --- | --- |
| class-led, utility-CSS page | +1.4% | −4.0% | −18.2% | −30.6% | −50.1% | **−63.3%** |
| tag-led, same page | +1.2% | +1.3% | −2.9% | −3.7% | | −27.5% |
| product listing, class-led | | | | −16.2% | | −31.3% |
| product listing, tag-led | +0.5% | +0.4% | −0.7% | −1.6% | | −7.0% |

Also −6.5% article, −9.1% table-heavy, −4.9% deep-nested at 32 fields; ±1% for a pure scan. `tools/bench_matrix.py` gains the class-led table this needed (`--class-led` runs just it): the existing tag-led pool barely exercises class work, so a matcher change is invisible there.

## Two results worth more than the speedup

Both are now in DESIGN.md's *rejected by measurement* list, so they aren't re-attempted:

- **Caching each element's split class tokens** on the open-element stack (inline `(start, len)` ranges, no allocation) was the obvious companion change and looked excellent alone: −27% to −51% on class-led schemas. On top of the filter it added only ~3% at 8+ class fields while taxing every other workload 8–11%, because it grew `OpenElem` by 40 bytes and that is a memcpy on every element push. **Reverted.** A 4-way interleaved sweep (base / cache / filter / both) is what separated them — measuring the two together would have credited the filter's win to the cache.
- **The filter is not free per element**, so each *kind* of bit has to earn its hash for the schema at hand. Hashing every element's class list to serve a *single* class-led field lost 11%; two fields gained 4%. Below two tests of a kind, the bits now leave the element signature and every `req` together (`sig::BITS_MIN`) — sound because one decision drives both sides — which turned the last regression into noise.

## Tests

- `filter_never_rejects_a_match` — the filtered predicate must equal the unfiltered one over every combination of tag/id/class-set on both sides, plus `:not()`/`:is()` wrappers whose bits must **not** be required. It also asserts the filter actually rejects a third of the pairs: an equivalence test alone would pass a filter that had been accidentally disabled.
- Case-sensitivity vectors, unit and end-to-end: `<DIV class="Foo bar" id="Bar">` against `div.Foo.bar#Bar`, `DIV.foo`, `div.FOO`, `div#bar` — and asserting the *signature itself* is what rejects the wrong-case forms, so a wrong case rule in the hash can't hide behind the downstream string compare.
- `wants`/`req` coverage per tier (normal, grouped container + sub-field, deferred reverse, deferred `:has`, and a deferred **tail**, which is its own sub-schema and must carry its own flags).

## Gates

All green: differential vs lxml **0 DIVERGE / 0 CRASH**, encoding parity, corpus parity, selector + malformed-HTML fuzz (fuzz `NOVEL` count byte-identical to the baseline build, so no new divergence class), tree-rule audit, support snapshot, pytest, `cargo test`, clippy. The `mutate` feature still builds.

## Reviewer notes

- `docs/BENCHMARKS.md` is **regenerated from one run** rather than hand-edited. Absolute µs are therefore not comparable to the previous publication (machine state moves them 5–10%); the two sections needing a corpus this repo doesn't ship are marked as pre-filter floors instead of being silently mixed in with new numbers. README ranges were updated to match, since it names BENCHMARKS.md as canonical.
- `Compound` gains a `pub req: u64` field. It is derived, not parsed: the CSS/XPath parsers leave it 0, and 0 always means "filter nothing".
- Compile pays ~0.4 µs more per schema (11 selectors, measured directly). `Plan`/`Page` reuse amortizes that away; a one-shot `extract` on a ~1 KB page can still see a percent or two, which is why the tiny `tests/corpus` pages read as noise.
- An **ancestor** OR-signature would let `div.foo a` reject at the subject before the `O(depth × compounds)` walk. Deliberately left out as a separate change with its own measurement; `sig.rs` says so in a "Not done here" section.
