### PR TITLE
Move the per-directory repo map out of the always-loaded agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,25 +100,8 @@ a way it has read 100% while the engine was wrong:
   → `Item` layer over `extract` (naming + cardinality only; no matching logic), plus `CompiledPage`.
   `python.rs` (feature-gated) is the PyO3 binding — `extract`/`extract_grouped`/`audit_schema`/`Plan`.
   `src/bin/{differ,bench}.rs` back the Python harness.
-- `python/frostwork/` — the Python package (pure Python over the `_frostwork` extension): `page.py`
-  (`extract` wrapper + `Page`/`Item`), `webpoet.py` (`FrostPage`/`field` web-poet integration, soft
-  dep), `audit.py` (`frostwork-audit` CLI: schema audit + `--scan`), `scan.py` (ast-based selector-literal
-  scan for un-ported source — inline `.css()`, ItemLoaders, LinkExtractors). `pyproject.toml` = maturin
-  build; `tests/test_python.py` = pytest suite.
-- `tools/` — Python differential/benchmark harness (needs `parsel`). `oracle.py` guards the oracle
-  toolchain (libxml2 ≥ 2.14 — a pinned lxml does *not* pin its vendored libxml2); `diff_lxml.py` is the gate;
-  `conformant.py`/`families.py`/`foreign.py` generate test pages; `enc_check.py` (encoding parity),
-  `sel_fuzz.py`/`diff_fuzz.py` (selector + malformed-HTML fuzz), `soak.py` (multi-seed soak),
-  `support_snapshot.py` (regenerates/checks `docs/SUPPORT_SNAPSHOT.md`), `abi3_smoke.py` (stdlib-only
-  floor check — the pinned toolchain can't be installed on py3.9), `bench_matrix.py`/
-  `bench_corpus.py`/`bench_mem.py` (benchmarks). Three tools own the tree-construction rules and share
-  ONE element universe: `gen_tree_rules.py` derives the rules from libxml2 and GENERATES the Rust table
-  (`--check` gates on drift, `--report` prints the derivation); `audit_tree_rules.py` asks lxml whether
-  every rule cell is RIGHT, by value, through the real engine; `mutate_rules.py` asks whether a WRONG one
-  would be noticed (flips a cell via the `mutate` cargo feature and reruns the gates). `corpus_fetch.py`
-  fetches real pages into a gitignored corpus.
-- `docs/` — `COMPATIBILITY.md` (contract), `DESIGN.md` (architecture), `PYTHON.md` (bindings),
-  `TESTING.md`, `BENCHMARKS.md`, `MIGRATION.md` (from Parsel), `SUPPORT_SNAPSHOT.md` (generated).
+- `python/frostwork/` — the Python package over the `_frostwork` extension. See `python/AGENTS.md`.
+- `tools/` — Python differential/benchmark harness (needs `parsel`). See `tools/AGENTS.md`.
 
 ## Principles to preserve
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ divergences and zero crashes against the pinned Parsel/lxml oracle.
 - Benchmarks: [docs/BENCHMARKS.md](docs/BENCHMARKS.md).
 - Parsel migration guide: [docs/MIGRATION.md](docs/MIGRATION.md).
 - Runnable examples: `cargo run --example basic` and `.venv/bin/python examples/basic.py`.
+- Conventions for contributors and coding agents: [AGENTS.md](AGENTS.md).
 
 ## Status
 

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -1,0 +1,7 @@
+# python/ — the Frostwork Python package
+
+Pure Python over the `_frostwork` extension: `page.py` (`extract` wrapper + `Page`/`Item`),
+`webpoet.py` (`FrostPage`/`field` web-poet integration, soft dep), `audit.py` (`frostwork-audit`
+CLI: schema audit + `--scan`), `scan.py` (ast-based selector-literal scan for un-ported source —
+inline `.css()`, ItemLoaders, LinkExtractors). `pyproject.toml` = maturin build;
+`tests/test_python.py` = pytest suite.

--- a/python/CLAUDE.md
+++ b/python/CLAUDE.md
@@ -1,0 +1,6 @@
+# CLAUDE.md
+
+Guidance for this directory lives in [AGENTS.md](AGENTS.md), imported below so Claude Code loads it;
+other tools should read AGENTS.md itself.
+
+@AGENTS.md

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -1,0 +1,16 @@
+# tools/ — the differential/benchmark harness
+
+Python harness (needs `parsel`). `oracle.py` guards the oracle toolchain (libxml2 ≥ 2.14 — a pinned
+lxml does *not* pin its vendored libxml2); `diff_lxml.py` is the gate; `conformant.py`/`families.py`/
+`foreign.py` generate test pages; `enc_check.py` (encoding parity), `sel_fuzz.py`/`diff_fuzz.py`
+(selector + malformed-HTML fuzz), `soak.py` (multi-seed soak), `support_snapshot.py`
+(regenerates/checks `docs/SUPPORT_SNAPSHOT.md`), `abi3_smoke.py` (stdlib-only floor check — the
+pinned toolchain can't be installed on py3.9), `bench_matrix.py`/`bench_corpus.py`/`bench_mem.py`
+(benchmarks).
+
+Three tools own the tree-construction rules and share ONE element universe: `gen_tree_rules.py`
+derives the rules from libxml2 and GENERATES the Rust table (`--check` gates on drift, `--report`
+prints the derivation); `audit_tree_rules.py` asks lxml whether every rule cell is RIGHT, by value,
+through the real engine; `mutate_rules.py` asks whether a WRONG one would be noticed (flips a cell
+via the `mutate` cargo feature and reruns the gates). `corpus_fetch.py` fetches real pages into a
+gitignored corpus.

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -1,0 +1,6 @@
+# CLAUDE.md
+
+Guidance for this directory lives in [AGENTS.md](AGENTS.md), imported below so Claude Code loads it;
+other tools should read AGENTS.md itself.
+
+@AGENTS.md


### PR DESCRIPTION
## What

- Move the `python/` and `tools/` repo-map bullets from `AGENTS.md` into `python/AGENTS.md` and `tools/AGENTS.md`, leaving a one-line pointer to each in the root file.
- Add `python/CLAUDE.md` and `tools/CLAUDE.md` — the same `@AGENTS.md` import shim the repo root already uses.
- Delete the `docs/` bullet from the repo map.
- Link `AGENTS.md` from the README's doc list.

Net: `AGENTS.md` goes from 13,095 to 11,486 characters.

## Why

Every line of the root agent guide sits in an agent's context for every session, whether or not that session touches the directory being described. The two moved bullets are pure per-directory description, so they can load only when work is happening under those paths. Nothing normative moved: the rule-table and oracle directives stay in *Conventions* and the gate-limits section, since they apply wherever you are in the tree.

The `docs/` bullet listed the filenames `ls docs/` prints, with labels the filenames already imply, and the intro already points at README/DESIGN/COMPATIBILITY as the entry points.

The README line goes in the doc list directly under `make ci`, which is where a contributor is already looking for the workflow `AGENTS.md` documents.

## Reviewer notes

- **The nested files are `AGENTS.md` with a `CLAUDE.md` shim, matching the root.** Keeping content in the tool-neutral file means contributors running something other than Claude Code get the same guidance, and the Claude-specific file stays a disposable adapter.
- **Trade-off worth a second opinion:** root `AGENTS.md` is read by essentially every agent tool, while nested `AGENTS.md` is nearest-file-wins — honored by Claude Code and Codex, but some simpler tools only read the root. So this trades a bit of universal reach for roughly 400 tokens of per-session context. Reasonable people could prefer keeping it all in the root file; reverting is a clean `git revert`.
- No engine or test changes — documentation only, so the differential gate is unaffected.
