### PR TITLE
Scan an end tag's attributes, because a quoted value in one carries the `>`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,17 @@ a way it has read 100% while the engine was wrong:
   attributed to foster-parenting, misnesting or deep-`<p>` — because attribution asks "does this PAGE
   contain the construct", and a truncated page usually also contains a table. **Page-scoped attribution
   over-credits**: when one documented bucket never empties, suspect the bucket, not the page.
+  Three more 10000-page samples then found ONE bug between them, and its interest is entirely in how it
+  hid: **an end tag has a start tag's attribute states**, so a quoted value in one carries the `>`. A
+  Blogger template writes `</img\nsrc="http:>`, whose unterminated value runs to the next quote 300 bytes
+  later; libxml2 and html5lib swallow the markup in between and the engine — "scan a name, skip to `>`" —
+  kept a `<div id='HTML3'>` that is in no other parser's tree. It was 63 of the 63 UNEXPLAINED columns
+  across the three samples and **the same one page shape each time**, which is what a long-tail template
+  bug looks like: three independent 10k samples, three hits, one construct. The malformed-HTML fuzzer
+  could not have found it — nothing in `diff_fuzz.py` emitted an end tag with an attribute at all, so the
+  whole surface rode on hand vectors, exactly as the CSS-escape gap did. Its new `end_tag_attr` mutation
+  then found the SAME rule broken in two more scanners (rawtext/RCDATA and `<script>`) on its first run.
+  **One fixed call site is not a fixed rule**: grep for the others before believing the gate.
   None of these are exotic;
   they are just markup nobody thought to generate. Sampling the real web is not optional — and when a
   check samples (800 characters, 30 pages), say so where the number is quoted, because "we measured N and

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -246,6 +246,13 @@ DOM, no full tree construction). These rules were derived empirically against li
   "scan a name, skip to `>`" merged a real page's `Copyright 1991-2026</%> VECMAR Corporation` into one
   text node where libxml2 has two, and was also the largest single source of unattributed divergences in
   the malformed-HTML fuzzer.
+- **An end tag has a start tag's ATTRIBUTE states, and discards what they collect.** So — unlike the
+  bogus comment above — a quoted value in an end tag carries the `>`: `</p x=">">` ends at the *second*
+  `>`, and an unterminated one runs to the next matching quote or to EOF, swallowing whatever markup is
+  in between. A Blogger template that writes `</img\nsrc="http:>` had libxml2 and html5lib eat the
+  following `</a>`, two `</div>`s and a whole `<div id='HTML3'>` start tag; ending the tag at the first
+  `>` instead kept an element that is in no other parser's tree — a FALSE POSITIVE. The rule covers the
+  rawtext/RCDATA and `<script>` closers too, which are separate scanners.
 - **`<p>`-closing block set** is the HTML4 block list (`div`, `p`, `h1`–`h6`, `ul`, `ol`, `dl`, `menu`,
   `dir`, `center`, `address`, `blockquote`, `fieldset`, `form`, `pre`, `table`, `hr`) — **not** the
   HTML5 sectioning elements (`section`, `article`, `header`, `footer`, `nav`, `main`, `figure`,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -159,7 +159,18 @@ fn skip_to_gt(b: &[u8], from: usize) -> usize {
 
 /// Scan RAWTEXT/RCDATA content for the matching `</name` end tag (case-insensitive). Returns
 /// (text_end, after_end_tag).
-fn find_raw_end(b: &[u8], from: usize, name: &[u8]) -> (usize, usize) {
+///
+/// The appropriate end tag gets a start tag's ATTRIBUTE states here too — see `scan_attrs`. Ending it
+/// at the first `>` instead was the same bug in a second place, and it is the malformed-HTML fuzzer's
+/// new `end_tag_attr` mutation that turned it up on its first run: `<title>x</title\nsrc='y:>` has no
+/// later `'`, so libxml2 reads the whole rest of the document as that attribute's value and keeps
+/// nothing, while the engine closed the title and kept the page.
+fn find_raw_end<'a>(
+    b: &'a [u8],
+    from: usize,
+    name: &[u8],
+    attr_buf: &mut Vec<(&'a [u8], Option<&'a [u8]>)>,
+) -> (usize, usize) {
     let n = b.len();
     let mut i = from;
     loop {
@@ -180,7 +191,7 @@ fn find_raw_end(b: &[u8], from: usize, name: &[u8]) -> (usize, usize) {
                         }
                     }
                     if ok && (q >= n || is_ws(b[q]) || b[q] == b'>' || b[q] == b'/') {
-                        return (p, skip_to_gt(b, q));
+                        return (p, scan_attrs(b, q, attr_buf).0);
                     }
                 }
                 i = p + 1;
@@ -210,7 +221,15 @@ fn tag_name_at(b: &[u8], p: usize, prefix: &[u8], name: &[u8]) -> Option<usize> 
 /// conditional-comment wrappers. Inside `<!-- ...`, a nested `<script>` enters double-escaped state:
 /// its first `</script>` is text (it only returns to escaped), so it must not close the outer script.
 /// Missing this state turns the remainder of a real page into markup and globally desynchronizes it.
-fn find_script_end(b: &[u8], from: usize) -> (usize, usize) {
+///
+/// The two `</script`s that CLOSE the element take a start tag's attribute states (`scan_attrs`); the
+/// double-escaped one does not, because it only returns to the escaped state — its attributes stay
+/// text, so it continues from just past the name.
+fn find_script_end<'a>(
+    b: &'a [u8],
+    from: usize,
+    attr_buf: &mut Vec<(&'a [u8], Option<&'a [u8]>)>,
+) -> (usize, usize) {
     #[derive(Clone, Copy)]
     enum State {
         Data,
@@ -239,12 +258,12 @@ fn find_script_end(b: &[u8], from: usize) -> (usize, usize) {
                     continue;
                 }
                 if let Some(q) = tag_name_at(b, i, b"</", b"script") {
-                    return (i, skip_to_gt(b, q));
+                    return (i, scan_attrs(b, q, attr_buf).0);
                 }
             }
             State::Escaped => {
                 if let Some(q) = tag_name_at(b, i, b"</", b"script") {
-                    return (i, skip_to_gt(b, q));
+                    return (i, scan_attrs(b, q, attr_buf).0);
                 }
                 if let Some(q) = tag_name_at(b, i, b"<", b"script") {
                     state = State::DoubleEscaped;
@@ -340,7 +359,11 @@ fn handle_markup<'a, S: TokenSink<'a>>(
                     while i < n && is_name_char(b[i]) {
                         i += 1;
                     }
-                    let after = skip_to_gt(b, i);
+                    // The same attribute states as a start tag, whose collected attributes an end tag
+                    // then discards — see `scan_attrs`. An unterminated end tag is still emitted (a
+                    // start tag's is dropped): every EOF shape agrees with libxml2 and html5lib either
+                    // way, since end-of-document closes the element regardless.
+                    let (after, _, _) = scan_attrs(b, i, attr_buf);
                     sink.end_tag(&b[start..i], p, after); // p = '<' of the end tag
                     after
                 }
@@ -362,20 +385,24 @@ fn handle_markup<'a, S: TokenSink<'a>>(
     }
 }
 
-fn handle_start<'a, S: TokenSink<'a>>(
+/// Scan a tag's attribute list, from just past the tag NAME to just past its `>`, collecting the
+/// attributes into `attr_buf`. Returns `(offset, terminated, self_closing)`; `terminated` is false
+/// when the input ran out before the `>`.
+///
+/// END tags come through here too, and must: HTML5 gives them the same attribute states as start
+/// tags, and only DISCARDS what they collect. The difference that matters is quoting — a `"` after
+/// `=` opens a value that runs to the next `"`, so a `>` inside it does not end the tag. Reading an
+/// end tag as "scan a name, skip to `>`" instead ended it early, and a Blogger template that emits
+/// `</img\nsrc="http:>` (unterminated, so the value runs on to the next quote 300 bytes later) then
+/// kept an `</a>`, two `</div>`s and a whole `<div id='HTML3'>` start tag that libxml2 and html5lib
+/// both swallow — reporting an element that is not in the document, the FALSE-POSITIVE direction.
+/// Two 10000-page crawl samples found it, 29 and 32 divergent columns, one page each.
+fn scan_attrs<'a>(
     b: &'a [u8],
-    p: usize,
-    sink: &mut S,
+    mut i: usize,
     attr_buf: &mut Vec<(&'a [u8], Option<&'a [u8]>)>,
-) -> usize {
+) -> (usize, bool, bool) {
     let n = b.len();
-    let mut i = p + 1;
-    let ns = i;
-    while i < n && is_name_char(b[i]) {
-        i += 1;
-    }
-    let name = &b[ns..i];
-
     attr_buf.clear();
     let mut self_closing = false;
     let mut terminated = false;
@@ -450,6 +477,25 @@ fn handle_start<'a, S: TokenSink<'a>>(
             attr_buf.push((aname, aval));
         }
     }
+    (i, terminated, self_closing)
+}
+
+fn handle_start<'a, S: TokenSink<'a>>(
+    b: &'a [u8],
+    p: usize,
+    sink: &mut S,
+    attr_buf: &mut Vec<(&'a [u8], Option<&'a [u8]>)>,
+) -> usize {
+    let n = b.len();
+    let mut i = p + 1;
+    let ns = i;
+    while i < n && is_name_char(b[i]) {
+        i += 1;
+    }
+    let name = &b[ns..i];
+
+    let (end, terminated, self_closing) = scan_attrs(b, i, attr_buf);
+    i = end;
 
     if !terminated {
         // EOF before the closing `>`: the tag is DROPPED, whole. Not emitted, and not turned back into
@@ -473,8 +519,8 @@ fn handle_start<'a, S: TokenSink<'a>>(
             DataMode::Plaintext => (n, n),
             // `script` needs the escaped/double-escaped states on top of "find the end tag"; every
             // other mode ends at the first matching end tag.
-            _ if name.eq_ignore_ascii_case(b"script") => find_script_end(b, i),
-            _ => find_raw_end(b, i, name),
+            _ if name.eq_ignore_ascii_case(b"script") => find_script_end(b, i, attr_buf),
+            _ => find_raw_end(b, i, name, attr_buf),
         };
         if text_end > i {
             sink.text(&b[i..text_end], mode == DataMode::Rcdata, i);
@@ -561,6 +607,53 @@ mod tests {
         assert_eq!(toks(b"a</>b"), ["T:a", "T:b"]);
         // EOF right after `</` is character data
         assert_eq!(toks(b"a</"), ["T:a", "T:</"]);
+    }
+
+    /// An END TAG has a start tag's ATTRIBUTE states, and only throws the attributes away.
+    ///
+    /// Contrast the `a</% x=">">b` line above: a bogus comment really does stop at the first `>`, so
+    /// the two shapes differ by one character (`%` vs a letter) and consume different spans. Reading
+    /// the end tag with the bogus-comment rule is what a real Blogger template caught.
+    #[test]
+    fn end_tag_attributes_are_scanned_then_discarded() {
+        // a quoted value carries the `>` — the end tag continues past it
+        assert_eq!(toks(br#"a</p x=">">b"#), ["T:a", "E:p", "T:b"]);
+        assert_eq!(toks(br#"a</p x='>'>b"#), ["T:a", "E:p", "T:b"]);
+        // ...and an UNTERMINATED value runs to the next matching quote, swallowing whatever markup is
+        // in between. This is the crawled shape, minimized: `</img src="http:>` eats the start tag.
+        assert_eq!(
+            toks(br#"x</img
+src="http:></a><div id='HTML3'><i>" >y"#),
+            ["T:x", "E:img", "T:y"]
+        );
+        // an unquoted value and a bare solidus end where they always did
+        assert_eq!(toks(b"a</p foo=bar>b"), ["T:a", "E:p", "T:b"]);
+        assert_eq!(toks(b"a</p/>b"), ["T:a", "E:p", "T:b"]);
+        // EOF inside an end tag still EMITS it, unlike a start tag, which is dropped whole: every EOF
+        // shape agrees with libxml2 and html5lib either way, because end-of-document closes the
+        // element anyway. Pinned so the shared scanner's `terminated` flag can't quietly change it.
+        assert_eq!(toks(br#"a</p x="y"#), ["T:a", "E:p"]);
+        assert_eq!(toks(b"a</p"), ["T:a", "E:p"]);
+    }
+
+    /// ...and the RAWTEXT/RCDATA and SCRIPT closers get those states too — three call sites, one rule.
+    /// The fuzzer's `end_tag_attr` mutation found these two on its first run, after the plain end tag
+    /// above was already fixed.
+    #[test]
+    fn rawtext_end_tag_attributes_are_scanned_too() {
+        // RCDATA: the `>` inside the quoted value does not close the title
+        assert_eq!(toks(br#"<title>t</title x=">">after"#), ["S:title[]", "T:t", "E:title", "T:after"]);
+        // RAWTEXT
+        assert_eq!(toks(br#"<style>s</style x=">">after"#), ["S:style[]", "T!:s", "E:style", "T:after"]);
+        // SCRIPT's own scanner, in both the plain and the escaped state
+        assert_eq!(toks(br#"<script>s</script x=">">after"#), ["S:script[]", "T!:s", "E:script", "T:after"]);
+        assert_eq!(
+            toks(br#"<script><!--s</script x=">">after"#),
+            ["S:script[]", "T!:<!--s", "E:script", "T:after"]
+        );
+        // an UNTERMINATED value eats the rest of the document — no later quote to close it, which is
+        // exactly the shape the fuzzer produced (`</title\nsrc='y:>`), and libxml2 keeps nothing after it
+        assert_eq!(toks(b"<title>t</title\nsrc='y:><p>gone"), ["S:title[]", "T:t", "E:title"]);
     }
 
     #[test]

--- a/tools/diff_fuzz.py
+++ b/tools/diff_fuzz.py
@@ -101,6 +101,20 @@ def m_dup_attr(rng, s):
     return s[: m.start()] + m.group(1) + m.group(2) + " " + m.group(2).strip() + m.group(3) + s[m.end():]
 
 
+def m_end_tag_attr(rng, s):
+    # An END tag carrying an attribute. Nothing in this file could emit one, so the whole end-tag
+    # attribute-state surface rode on hand vectors — and a crawled Blogger template that writes
+    # `</img\nsrc="http:>` broke it: the quoted value swallows the `>` and everything up to the next
+    # quote, which libxml2 and html5lib both do and the engine did not. The unquoted form is the
+    # control: it must NOT change where the tag ends.
+    ends = list(re.finditer(r"</[a-zA-Z][^\s/>]*", s))
+    if not ends:
+        return s
+    m = rng.choice(ends)
+    attr = rng.choice([' src="http:', " src=http:", ' src="x"', "\nsrc='y:", " /", ' ="q"'])
+    return s[: m.end()] + attr + s[m.end():]
+
+
 def m_lt_in_attr(rng, s):
     vals = list(re.finditer(r'="[^"<>]*"', s))
     if not vals:
@@ -172,7 +186,7 @@ STR_MUTS = [
     ("swap_adjacent_close", m_swap_adjacent_close), ("foster", m_foster),
     ("stray_close", m_stray_close), ("dup_attr", m_dup_attr), ("lt_in_attr", m_lt_in_attr),
     ("self_close_nonvoid", m_self_close_nonvoid), ("comment_bait", m_comment_bait),
-    ("deep_nest", m_deep_nest),
+    ("deep_nest", m_deep_nest), ("end_tag_attr", m_end_tag_attr),
 ]
 BYTE_MUTS = [
     ("truncate", m_truncate), ("drop_bytes", m_drop_bytes), ("insert_bytes", m_insert_bytes),


### PR DESCRIPTION
## The bug

HTML5 gives an end tag the **same attribute states as a start tag**, and only discards the attributes it collects. libxml2 follows this. The tokenizer instead read every end tag as *"scan a name, then skip to the next `>`"*, which mis-tokenizes any end tag carrying an attribute:

```html
</p x=">">        <!-- should end at the SECOND `>`; ended at the first -->
</p x="unclosed   <!-- should run to the next `"` or to EOF; ended at the first `>` -->
```

Ending the tag early leaves the remaining bytes to be re-tokenized as markup that no conforming parser sees, which produces **false positives** — elements and values reported out of a region both libxml2 and html5lib discard. That is the one outcome the project's no-fallback contract exists to prevent: an unsupported query may return nothing, but a supported one must never return something that isn't there. The converse also occurred — markup following an unterminated value should be swallowed, and was kept.

A minimal reproducer:

```
<div></div src=">x<p>P</p>"><span>S</span>
```

`p` matched in this engine; libxml2 and html5lib both have no `<p>` at all.

## Why real pages hit it

A widespread broken-template shape is an `<img>` closed with an end tag that carries the attributes:

```html
<img src="..."></img
src="http:>
```

The template quotes its own attributes with `'`, so that `"` opens a value with no closing quote for several hundred bytes. libxml2 and html5lib consume the intervening `</a>`, two `</div>`s and an entire `<div id='HTML3'>` start tag. This engine kept all of them, reporting a `div` that exists in no other parser's tree.

## The fix

The single attribute-scanning loop now lives in `scan_attrs`, shared by **all four** places that close a tag:

| site | shape it got wrong |
|---|---|
| ordinary end tag | `</p x=">">` |
| `find_raw_end` (RAWTEXT/RCDATA) | `<title>t</title x=">">` |
| `find_script_end`, data state | `<script>s</script x=">">` |
| `find_script_end`, escaped state | `<script><!--s</script x=">">` |

Fixing only the first would have left the other three wrong — worth noting for anyone auditing a similar rule.

## Deliberately unchanged, now pinned by test

- **The double-escaped `</script` takes no attributes.** It only returns to the escaped state, so its attributes stay text; it continues from just past the name.
- **An unterminated end tag is still emitted**, where an unterminated *start* tag is dropped whole. Every end-of-input shape agrees with both oracles either way, because end-of-document closes the element regardless.
- **A bogus comment (`</%>`) still stops at the first `>`, quoting and all.** It and a real end tag differ by a single character and consume different spans — that contrast is what made the original rule easy to get wrong.

## Testing

`tools/diff_fuzz.py` could not emit an end tag with an attribute at all, so this surface had no generated coverage — it rode entirely on hand-written vectors. The new `end_tag_attr` mutation closes that gap, and discriminates sharply:

| | DIVERGE | NOVEL |
|---|---|---|
| pre-fix build | 22997 | 7563 |
| this branch | **0** | **0** |

over 549000 pairs (`--only end_tag_attr --iters 3000 --per 2 --seed 7`). New token-layer unit tests cover all four scanners plus the unchanged behaviours above.

Every local gate is green: unit tests, `clippy -D warnings`, the lxml differential, encoding parity, the corpus and token-sequence gates, both fuzzers, the Python suite, rule-table drift and the full rule-cell audit. Engine throughput is unchanged (~257 → 259 µs/page, within run-to-run noise).