### PR TITLE
Reject most selector tests before touching a string, and shrink the per-element push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,7 +250,9 @@ a way it has read 100% while the engine was wrong:
   faithfully vs. stay unsupported), `matching.rs` (pure read-only match predicates), `deferred.rs`
   (bounded state machines for deferred-close predicates), `frame.rs` (document-frame state and the NAMED
   questions the frame rules ask about it — read its header before touching one), `decode.rs` (value
-  decoding). `selector.rs` (CSS parse), `xpath.rs` (downward XPath → `Selector`), `diagnostics.rs`
+  decoding), `sig.rs` (the ONE-SIDED element/compound Bloom signatures `compound_matches` opens with — a
+  set bit is necessary, never sufficient; read its header before touching the hash or the class
+  tokenizer). `selector.rs` (CSS parse), `xpath.rs` (downward XPath → `Selector`), `diagnostics.rs`
   (advisory unsupported-reason classifier for the audit API), `implied_close/` (libxml2 tree-construction
   rules: `generated.rs` is derived from the oracle, `mod.rs` is the hand-written half),
   `encoding.rs`, `entities.rs`, `mutate.rs` (an identity function unless built
@@ -304,3 +306,15 @@ a way it has read 100% while the engine was wrong:
 - Rust: exhaustive `match`, keep `clippy` clean. Measure before optimizing (SIMD structural indexing
   and a tag-dispatch index were both prototyped and *rejected* by measurement — don't re-attempt
   without a workload that shows a win).
+- **Performance work: measure with `tools/ab_bench.py` and read the jitter column.** It interleaves two
+  `bench` builds inside each cell (A,B,A,B…, min-of-reps) because sequential runs drift 5–10%, and prints
+  each cell's own spread, marking with `~` any delta inside it — two identical binaries produce per-cell
+  deltas up to ±2.3%, so a sub-2% cell is not evidence. Calibrate by passing the same binary as `--a` and
+  `--b`. Run nothing else meanwhile. And a pool only measures what it contains: the tag-led pool cannot
+  see class matching, `CLASS_POOL` is subject-led at its head so it cannot see the ancestor walk, and
+  neither holds an attribute predicate — adding the pool that can see a change is part of the change.
+- **A pre-filter must be cheaper than what it guards for the schemas that cannot use it.** Both matcher
+  filters are gated on a measured floor for this reason (`sig::BITS_MIN`, `AttrGate::MIN_NAMES`).
+- **`OpenElem`'s size is a performance lever.** Pushing an element memcpies the whole struct, so a field
+  added there is paid per element on every page; 16 bytes measured ~3.6% on a pure scan.
+  `stays_small_enough_to_push_cheaply` asserts the ceiling and names the benchmark to run before raising it.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -4,45 +4,50 @@ Engine-only throughput (Rust `bench` binary, no IPC in the timed loop) vs Parsel
 parse once, then one `.css()` per field). Both run the same selectors on the same page, with values
 checked before timing. Results are warm runs on one Apple arm64 machine: indicative, not controlled.
 Selector counts are prefixes of one product/article pool. Reproduce with
-`.venv/bin/python tools/bench_matrix.py`.
+`.venv/bin/python tools/bench_matrix.py` (`--markdown` regenerates the tables below rather than having
+them transcribed by hand). Before comparing any cell here against a figure measured elsewhere, read
+"An absolute µs figure is only comparable inside its own run".
 
 ## Page type × selector count (µs/page)
 
+Regenerated with `tools/bench_matrix.py --markdown`. The former `corpus (real-shaped)` row is absent: it
+reads a gitignored fixture, so it is not reproducible from a clean checkout (`make corpus-real` fetches
+one).
+
 | page (≈196 KB) | sels | engine µs | engine MB/s | Parsel µs | speedup |
 | --- | --- | --- | --- | --- | --- |
-| **article** (text-heavy) | 1 | 58 | 3451 | 560 | 9.6× |
-|  | 4 | 136 | 1475 | 2706 | 19.9× |
-|  | 8 | 270 | 745 | 5324 | 19.8× |
-|  | 16 | 358 | 560 | 6427 | 17.9× |
-|  | 26 | 479 | 419 | 9686 | 20.2× |
-|  | 32 | 556 | 361 | 11212 | 20.2× |
-| **product&#95;listing** | 1 | 256 | 782 | 2619 | 10.2× |
-|  | 4 | 747 | 268 | 15313 | 20.5× |
-|  | 8 | 1068 | 188 | 22123 | 20.7× |
-|  | 16 | 1838 | 109 | 80254 | 43.7× |
-|  | 26 | 2671 | 75 | 144615 | 54.1× |
-|  | 32 | 2924 | 68 | 144178 | 49.3× |
-| **table-heavy** | 1 | 360 | 556 | 3192 | 8.9× |
-|  | 8 | 1029 | 195 | 13432 | 13.1× |
-|  | 16 | 1814 | 110 | 44571 | 24.6× |
-|  | 32 | 3550 | 56 | 98915 | 27.9× |
-| **deep-nested** (20-deep) | 1 | 619 | 324 | 3211 | 5.2× |
-|  | 8 | 1296 | 154 | 12560 | 9.7× |
-|  | 16 | 2252 | 89 | 41175 | 18.3× |
-|  | 32 | 3861 | 52 | 57569 | 14.9× |
-| **corpus** (real-shaped, 567 KB) | 1 | 175 | 3322 | 2070 | 11.8× |
-|  | 8 | 712 | 815 | 8661 | 12.2× |
-|  | 16 | 1346 | 431 | 67613 | 50.2× |
-|  | 26 | 1880 | 309 | 83608 | 44.5× |
-|  | 32 | 2094 | 277 | 85213 | 40.7× |
+| **article** (text-heavy) | 1 | 91 | 2204 | 582 | 6.4× |
+|  | 4 | 200 | 1003 | 2951 | 14.7× |
+|  | 8 | 301 | 666 | 5807 | 19.3× |
+|  | 16 | 374 | 537 | 7570 | 20.2× |
+|  | 26 | 672 | 299 | 12079 | 18.0× |
+|  | 32 | 652 | 308 | 13008 | 19.9× |
+| **product&#95;listing** | 1 | 466 | 430 | 3246 | 7.0× |
+|  | 4 | 1053 | 190 | 17299 | 16.4× |
+|  | 8 | 1631 | 123 | 25910 | 15.9× |
+|  | 16 | 2398 | 84 | 97532 | 40.7× |
+|  | 26 | 3356 | 60 | 174036 | 51.9× |
+|  | 32 | 3396 | 59 | 177933 | 52.4× |
+| **table-heavy** | 1 | 679 | 295 | 4036 | 5.9× |
+|  | 4 | 1207 | 166 | 15405 | 12.8× |
+|  | 8 | 1382 | 145 | 16760 | 12.1× |
+|  | 16 | 2388 | 84 | 54811 | 22.9× |
+|  | 26 | 3273 | 61 | 95816 | 29.3× |
+|  | 32 | 3992 | 50 | 119906 | 30.0× |
+| **deep-nested** (20-deep) | 1 | 1038 | 193 | 4766 | 4.6× |
+|  | 4 | 1500 | 133 | 13682 | 9.1× |
+|  | 8 | 1909 | 105 | 16587 | 8.7× |
+|  | 16 | 2952 | 68 | 49423 | 16.7× |
+|  | 26 | 3632 | 55 | 61447 | 16.9× |
+|  | 32 | 4463 | 45 | 63235 | 14.2× |
 
 ## Size sweep (product_listing, 8 selectors)
 
 | size | engine µs | engine MB/s | Parsel µs | speedup |
 | --- | --- | --- | --- | --- |
-| 19 KB | 111 | 181 | 2176 | 19.6× |
-| 195 KB | 1068 | 188 | 21545 | 20.2× |
-| 976 KB | 5285 | 189 | 110631 | 20.9× |
+| 19 KB | 152 | 133 | 2544 | 16.7× |
+| 195 KB | 1482 | 135 | 26829 | 18.1× |
+| 976 KB | 7357 | 136 | 131214 | 17.8× |
 
 ## Grouped (Many/One) — `.product` container × N sub-fields
 
@@ -51,29 +56,80 @@ per-container loop. Reproduce with `.venv/bin/python tools/bench_matrix.py`.
 
 | subs | engine µs | engine MB/s | vals/page | Parsel µs | speedup |
 | --- | --- | --- | --- | --- | --- |
-| 1 | 735 | 273 | 1006 | 14160 | 19.3× |
-| 3 | 1064 | 188 | 3018 | 34401 | 32.3× |
-| 5 | 1363 | 147 | 5030 | 55125 | 40.4× |
+| 1 | 869 | 230 | 1006 | 15190 | 17.5× |
+| 3 | 1157 | 173 | 3018 | 37810 | 32.7× |
+| 5 | 1478 | 136 | 5030 | 63696 | 43.1× |
 
 The shared scan keeps grouped growth below Parsel's per-container loop in this sweep. No super-linear
 growth appears at these schema sizes.
 
 ## Reading the numbers
 
-- **Typical speedup \~10–20×, rising to \~40–54× on selector-rich pages.** The engine's cost grows
-  roughly linearly with selector count and page size; Parsel's grows **super-linearly** once selectors
-  get descendant-heavy (`.product .price`, `.product ::text`) — cssselect translates each to XPath and
-  libxml2 re-walks per query, so at 16–32 fields Parsel balloons to 80–145 ms while the engine's single
-  pass stays in single-digit ms. The one-pass, no-DOM design is what widens the gap with field count.
-- **Constant speedup across size** (~20× from 19 KB to ~1 MB): both scale linearly, engine at a steady
-  ~189 MB/s on this page type.
-- **Throughput is page-shape-dependent.** Text-dominated pages (article, corpus) run 0.8–3.5 GB/s
-  because memchr bulk-skips text; tag-dense pages (table, listing, deep-nest) run 50–800 MB/s because
-  cost is per-element (classify + stack + per-selector match), not per-byte.
-- **Weak spot — deep nesting.** The 20-level page is the slowest Frostwork shape in this matrix (5–18×,
-  and 619 µs for one selector): structural matching walks the ancestor stack per element (`seg_match`),
+- **Typical speedup \~12–20×, rising to \~52× on selector-rich pages, and only \~5–7× at one field.**
+  The engine's cost grows roughly linearly with selector count and page size; Parsel's grows
+  **super-linearly** once selectors get descendant-heavy (`.product .price`, `.product ::text`) —
+  cssselect translates each to XPath and libxml2 re-walks per query, so at 16–32 fields Parsel reaches
+  98–178 ms while the engine's single pass stays in single-digit ms. The one-pass, no-DOM design is what
+  widens the gap with field count; the flip side is that a ONE-field schema is the weak case, because the
+  scan is paid whether or not there is anything to amortize it over.
+- **Constant speedup across size** (~17–18× from 19 KB to ~1 MB): both scale linearly, engine at a steady
+  ~135 MB/s on this page type.
+- **Throughput is page-shape-dependent.** Text-dominated pages (article) reach ~2.2 GB/s because memchr
+  bulk-skips text; tag-dense pages (table, listing, deep-nest) run 45–430 MB/s because cost is
+  per-element (classify + stack + per-selector match), not per-byte.
+- **Weak spot — deep nesting.** The 20-level page is the slowest Frostwork shape in this matrix (4.6–17×,
+  and ~1.0 ms for one selector): structural matching walks the ancestor stack per element (`seg_match`),
   so cost rises with depth. Parsel is also slow here, but Frostwork's absolute time is higher than on the
   other synthetic shapes.
+- **Run-to-run spread is ~5–15% per cell**, same binary, same machine. Two consecutive full regenerations
+  of this table differed by that much on the tag-dense cells. Treat a single absolute figure as
+  indicative and use `tools/ab_bench.py` for anything comparative.
+
+## An absolute µs figure is only comparable inside its own run
+
+These tables had not been re-run since the initial commit, across thirty commits of correctness work
+(derived tree-construction rules, document-frame synthesis, end-tag scope priorities, end-tag attribute
+states, input normalization). That work costs per element, so the previous figures were ~1.7× optimistic;
+everything here is regenerated.
+
+So these tables answer "how does this build compare to Parsel on this page shape" — a ratio measured
+inside one run. They do not answer "did this commit help": for that, A/B two builds with
+`tools/ab_bench.py`, and regenerate this file (`--markdown`) when per-element cost changes.
+
+**Open question, not addressed here:** ~1.7–1.9× absolute slowdown since the initial commit is a lot to
+charge to correctness without checking. Candidates in cost order: input normalization touching the whole
+document, frame rules per start tag, scope as a priority comparison, end tags scanning attribute states.
+
+## Selector-matching optimizations: measured deltas
+
+From `tools/ab_bench.py` (interleaved, min-of-reps, each cell carrying its own jitter). Two identical
+binaries disagree by up to 2.3% per cell here, so a sub-2% cell is not evidence; every figure below
+cleared its own jitter. Reproduce against this branch's merge base:
+
+```bash
+git worktree add /tmp/fw-base "$(git merge-base HEAD origin/main)"   # the build these are measured against
+(cd /tmp/fw-base && cargo build --release --bin bench)
+cargo build --release --bin bench
+.venv/bin/python tools/ab_bench.py --a /tmp/fw-base/target/release/bench \
+    --b target/release/bench --reps 15 --tables class-led,tag-led,attr-led,scan
+```
+
+| workload (196 KB page) | 1 | 2 | 4 | 8 | 16 | 32 fields |
+| --- | --- | --- | --- | --- | --- | --- |
+| **class-led selectors**, utility-CSS page | −6.5% | −7.7% | −17.0% | −25.8% | −42.8% | −55.0% |
+| **tag-led selectors**, same page | −8.3% | −7.6% | −4.5% | −5.4% | −15.2% | −20.7% |
+| **class-led selectors**, product listing | −10.7% | −10.5% | −12.0% | −16.5% | −21.8% | −25.3% |
+| **tag-led selectors**, product listing | −10.1% | −9.0% | −8.1% | −8.0% | −8.5% | −7.9% |
+| **attribute-predicate selectors**, attribute-heavy page | — | — | −4.1% | −5.4% | −7.7% | −9.5% |
+
+Plus, at every field count: pure scan (0 selectors) −10.3%, article −7.2%…−10.2%, tag-dense table
+−10.3%…−14.0%, deep-nested −9.2%…−13.0%, deferred-tail (`:has`/`:last-child`) −1.7%…−6.9%. The
+class-led column is the one that matters most for real page objects, and the real-corpus median is 11
+selectors/page — the middle of that table.
+
+Two negative results are recorded in [DESIGN.md](DESIGN.md)'s rejected list rather than here, because
+neither shipped: an ancestor signature (helps only above ~16 descendant-led fields, costs below that)
+and member dedup (zero exact duplicates exist across the corpus schemas).
 
 ## Real Zyte corpus (throughput)
 
@@ -85,6 +141,9 @@ real reuse pattern). The corpus itself is not distributed, but the harness runs 
 of page snapshots laid out as `<dir>/<page-object>/selectors.json` + `pages/*.html` (see
 `tools/bench_corpus.py`): `.venv/bin/python tools/bench_corpus.py <corpus_dir>` (build the extension
 release-first — see below).
+
+**Not re-run here** (the corpus is not on this machine), so it predates the selector-matching work below.
+The ratio is a floor, since that work only moved the engine's side down; the absolute µs is stale.
 
 | metric | Frostwork | Parsel | speedup |
 | --- | --- | --- | --- |
@@ -104,17 +163,21 @@ extension first, so a stale or debug build cannot be timed by accident).
 
 | fields | `FrostPage` ms | Parsel `WebPage` ms | speedup | running-loop ms (`FrostPage` / Parsel) | speedup |
 | --- | --- | --- | --- | --- | --- |
-| 1 | 0.32 | 0.90 | **3×** | 0.21 / 0.76 | **4×** |
-| 4 | 0.45 | 4.52 | **10×** | 0.59 / 4.48 | **8×** |
-| 8 | 0.59 | 13.17 | **22×** | 0.50 / 12.99 | **26×** |
-| 12 | 0.79 | 21.39 | **27×** | 0.67 / 21.22 | **32×** |
-| 16 | 0.91 | 25.01 | **27×** | 0.81 / 24.71 | **31×** |
-| 20 | 1.01 | 27.02 | **27×** | 0.90 / 26.53 | **29×** |
+| 1 | 0.30 | 0.87 | **3×** | 0.19 / 0.72 | **4×** |
+| 4 | 0.39 | 4.26 | **11×** | 0.32 / 4.24 | **13×** |
+| 8 | 0.52 | 12.46 | **24×** | 0.42 / 12.41 | **30×** |
+| 12 | 0.66 | 20.15 | **30×** | 0.55 / 20.09 | **36×** |
+| 16 | 0.83 | 23.32 | **28×** | 0.69 / 23.35 | **34×** |
+| 20 | 0.86 | 25.31 | **29×** | 0.75 / 24.82 | **33×** |
 
 40 KB page (220 product cards), field counts are prefixes of one growing schema. Same machine and caveats
 as the matrix above: single machine (Apple arm64), warm, median of 25 reps, indicative rather than
-controlled. Repeated runs land in **25×–29×** at the top of the sweep, so treat the last three rows as one
-number (~27×) rather than as a curve that peaks at 12 fields.
+controlled. Repeated runs land in **25×–30×** at the top of the sweep, so treat the last three rows as one
+number (~29×) rather than as a curve that peaks at 12 fields.
+
+An independent check on the selector-matching work: through the Python binding and a whole page object
+rather than the `bench` binary, every `FrostPage` cell came down 8–17% (1 field 0.32 → 0.30 ms, 8 fields
+0.59 → 0.52, 20 fields 1.01 → 0.86).
 
 The **running-loop** columns exist because the main ones charge `asyncio.run` — a fresh event loop per
 call — to the page object, while a crawler already has a loop running. Both sides are re-timed that way, not
@@ -219,13 +282,17 @@ build the whole lxml tree (RSS scales with the page); Frostwork streams past the
 
 | page | Parsel RSS | Frostwork RSS | Parsel time | Frostwork time | faster |
 | --- | --- | --- | --- | --- | --- |
-| 1 MB | 7.8 MB | 0.1 MB | 7.9 ms | 1.1 ms | 7.2× |
-| 4 MB | 30.0 MB | <0.1 MB | 32.2 ms | 4.4 ms | 7.4× |
-| 16 MB | 118.1 MB | 0.1 MB | 134.2 ms | 18.4 ms | 7.3× |
-| 64 MB | 472.2 MB | 0.3 MB | 541.0 ms | 70.9 ms | 7.6× |
+| 1 MB | 7.8 MB | 0.1 MB | 8.1 ms | 1.9 ms | 4.4× |
+| 4 MB | 30.1 MB | 0.4 MB | 34.4 ms | 7.5 ms | 4.6× |
+| 16 MB | 118.2 MB | 0.2 MB | 146.5 ms | 29.2 ms | 5.0× |
+| 64 MB | 472.3 MB | 0.1 MB | 547.1 ms | 119.3 ms | 4.6× |
 
 With this fixed-output selector set, Parsel's memory scales with page size while Frostwork stays below
-0.3 MB. Frostwork memory can still scale with returned values, as the corpus result below shows.
+0.5 MB — a 55× to 6000× difference that grows with the page, which is the property the whole design
+exists for. Frostwork memory can still scale with returned values, as the corpus result below shows.
+
+The **time** column aged the same way as the matrix at the top (previously 1.1–70.9 ms, 7.2–7.6×), for
+the same reason; the RSS story is unaffected.
 
 **Real pages** (largest 12 in the corpus, 2.3–3.7 MB): median incremental RSS is **0.3 MB vs 20.6 MB**;
 the median of the per-page ratios is **72×** (range 2×–394×, and 7–19× faster). The gap narrows to ~2–3× only on the field-rich / value-heavy

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -39,6 +39,17 @@ bytes ─▶ tokenizer (TokenSink: start/text/end) ─▶ corrected-stack matche
   feasible position, right to left. Greedy is sound because a deeper placement leaves strictly more room
   above (exchange argument), and grouping `>`-runs is what makes it sound: greedy on individual compounds
   gets `a > b c` against `<a><b><b><c>` wrong. Searching combinations instead was exponential.
+  Before any of that runs, each `(element, compound)` pair meets a **one-sided signature filter**
+  (`matcher/sig.rs`, the shape of WebKit/Blink's `SelectorFilter`): at open, an element hashes its tag
+  name, `id` and each `class` token to two bits each of a `u64`; each compiled compound carries the same
+  bits for its own positive tag/id/classes; `compound_matches` opens with `el.sig & c.req != c.req →
+  false`. One AND rejects most pairs before a string is touched. A set bit is **necessary, never
+  sufficient** — collisions produce false positives, which cost only the exact comparisons that always
+  ran, while a false negative would be a silently dropped value. So the hash must mirror each
+  predicate's own equality: the tag is ASCII-folded on both sides (`eq_ignore_ascii_case`), `id` and
+  class tokens are hashed verbatim (`==`), the class list is split by the **one** tokenizer the
+  membership predicate uses (ASCII whitespace, so `class="a\u{3000}b"` is one token on both sides), and
+  nothing is contributed by `:not()` (inverted), `:is()` (an OR), attribute predicates, or positions.
 - **Selectors** — `selector.rs` parses the CSS subset; `xpath.rs` compiles the **downward** XPath
   subset to the *same* `Selector` model (so XPath and CSS share matching + performance).
 
@@ -161,7 +172,7 @@ Retention per candidate is therefore two integers, and the streaming path is unt
 That "single bounded extra pass" is **per selector**, though: each deferred tail is its own sub-schema, so
 N tail-bearing fields over the same outer subtree re-scan it N times, losing the multi-selector scan
 sharing the main pass has. Measured on a 200 KB product listing (`bench_matrix`'s `TAIL_POOL`): one tail
-field costs ~2.6× a plain one and eight cost ~4.3×, i.e. the penalty grows with FIELD COUNT. Left as is
+field costs ~2.9× a plain one and eight cost ~5.0×, i.e. the penalty grows with FIELD COUNT. Left as is
 deliberately — the absolute cost is milliseconds and no real schema is tail-heavy yet — but it is now in
 the benchmark so the decision is revisitable. The fix, if it ever matters, is merging tails that share a
 deferred prefix into one sub-schema (their winner spans are identical by construction).
@@ -224,9 +235,39 @@ descendant's emission and stays an empty column.
   the parse cost per *schema*, not per *page*. The per-page recompile it removes is negligible against
   a large page's scan, but on small pages it dominates: ~3× fewer µs/page on a 244-byte page with 8
   selectors. `extract`/`extract_grouped` remain as one-shot convenience (a throwaway `Plan`).
-- **Rejected by measurement (do not re-attempt without a workload that shows a win):** a SIMD
-  structural index (the base scan is per-*element* bound, not per-byte; memchr already bulk-skips text)
-  and a subject-tag dispatch index (real selectors are class-led, so it can't bucket them).
+- **One-sided signature filter** (`matcher/sig.rs`, described under *Pipeline*) — the matcher's cost is
+  `selectors × elements`, and every pair used to pay string work: a `memcmp` per tag test, and per class
+  test an `attrs` scan plus a fresh split of `class=`. The filter answers "could this compound match at
+  all?" in one AND, which is where a class-led, high-field-count schema gets most of its time back:
+  −13% at 4 class-led fields, −24% at 8, −41% at 16, −54% at 32 on the utility-CSS page; −10%/−22% at
+  8/32 on the product listing; −2% to −19% on the tag-led pools, which use it far less. Each KIND of bit
+  is included only above `sig::BITS_MIN` tests of that kind, dropped from both sides together.
+- **Attribute materialization gate** (`matcher::AttrGate`) — the signature filter deliberately summarizes
+  only tag/id/class, because a prefix/substring test is not the token equality a hash can model, so an
+  attribute-predicate schema (`[data-testid=x]`, `a[href^="/p/"]`) got nothing from it. Its cost was
+  `attributes × interesting names` case-insensitive comparisons per element, growing with schema size just
+  where it hurts: a 32-field attribute-led schema names ~30 attributes while a real element carries half a
+  dozen the schema never asked for. One 64-bit set of `(first byte, length)` pairs rejects those in one
+  test, one-sided in the same direction as the signature (a set bit is necessary, never sufficient).
+  Measured −4% at 4 attribute-led fields to −9.5% at 32, neutral elsewhere. Applied only above a
+  name-count floor (`AttrGate::MIN_NAMES`): with one or two interesting names the scan it guards is a
+  single length comparison. The count is a proxy for what actually decides the trade — the fraction of a
+  page's attributes the schema ignores, highest on component-framework markup (`data-*`, `aria-*`).
+- **Rejected by measurement (do not re-attempt without a workload that shows a win):**
+  - a SIMD structural index — the base scan is per-*element* bound, not per-byte, and memchr already
+    bulk-skips text;
+  - a subject-tag dispatch index — real selectors are class-led, so it cannot bucket them;
+  - **caching each element's split `class=` tokens** on the open-element stack — worth −27% to −51% on
+    class-led schemas alone, but only ~3% on top of the signature filter while taxing every other
+    workload ~8–11%, for the 40 bytes it added to each stack element;
+  - an **eight-bytes-per-multiply hash** for the signature — no faster than byte-at-a-time FNV-1a,
+    because short tokens pay a variable-length copy per word;
+  - an **ancestor signature** (the OR of an element's and its open ancestors' bits, to reject `div.foo a`
+    before the ancestor walk) — ~5% at 24–32 descendant-led fields on a deep page, but +3% to +11% worse
+    at 4–16 even when gated, since the residue is a wider `Segment` and a branch in the hot walk, and the
+    corpus median of 11 fields/page sits in the losing half;
+  - **member dedup** — the corpus schemas contain zero exact duplicate selectors, and their shared
+    prefixes would be factored by a weaker form of that ancestor signature.
 
 The shape of the result is what the design predicts: the advantage over Parsel grows with field count,
 because the scan is paid once per page rather than once per field, and shrinks with nesting depth (the

--- a/src/matcher/matching.rs
+++ b/src/matcher/matching.rs
@@ -40,7 +40,29 @@ pub(super) fn reverse_matches(rev: &ReversePos, idx: u32, total: u32) -> bool {
 }
 
 /// Does compound `c` (tag / id / classes / attribute predicates / `:not()`) match element `el`?
+///
+/// Opens with the one-sided signature filter (see [`super::sig`]): one AND and one compare reject most
+/// (element, compound) pairs before any string is touched. A pair that survives falls through to the
+/// exact comparisons, unchanged — the filter is never allowed to answer `true`.
 pub(super) fn compound_matches(c: &Compound, el: &OpenElem) -> bool {
+    compound_matches_impl::<true>(c, el)
+}
+
+/// [`compound_matches`] with the signature filter off at every level — the reference the filtered path is
+/// proven equal to (`filter_never_rejects_a_match`). A const generic rather than a second body, so the
+/// two cannot drift.
+#[cfg(test)]
+pub(super) fn compound_matches_unfiltered(c: &Compound, el: &OpenElem) -> bool {
+    compound_matches_impl::<false>(c, el)
+}
+
+fn compound_matches_impl<const FILTER: bool>(c: &Compound, el: &OpenElem) -> bool {
+    // One-sided: a `req` bit the element lacks proves no match, so this can only turn a `false` into a
+    // faster `false`. `req` covers only the compound's own positive tag/id/classes — `:not()` args and
+    // `:is()` alternatives contribute nothing here and are filtered by their own recursive call below.
+    if FILTER && el.sig & c.req != c.req {
+        return false;
+    }
     if let Some(t) = &c.tag {
         if t != "*" && !el.tag.eq_ignore_ascii_case(t.as_bytes()) {
             return false;
@@ -80,14 +102,14 @@ pub(super) fn compound_matches(c: &Compound, el: &OpenElem) -> bool {
     }
     // `:not(<compound>)` — excluded if the element matches any negation arg
     for neg in &c.negations {
-        if compound_matches(neg, el) {
+        if compound_matches_impl::<FILTER>(neg, el) {
             return false;
         }
     }
     // `:is(...)`/`:where(...)` — for each group the element must match at least one alternative (OR
     // within a group, AND across groups). Alternatives are plain compounds (no positional/deferred).
     for group in &c.is_groups {
-        if !group.iter().any(|alt| compound_matches(alt, el)) {
+        if !group.iter().any(|alt| compound_matches_impl::<FILTER>(alt, el)) {
             return false;
         }
     }
@@ -310,8 +332,12 @@ mod seg_match_tests {
         go(&seg.parts, &seg.combs, seg.parts.len() - 1, stack, si, floor, anchor_bit, seg.strict)
     }
 
+    /// Through `set_req`, as the matcher's are: otherwise the sweep runs with `req == 0` and never
+    /// exercises the filter.
     fn compound(tag: &str) -> Compound {
-        Compound { tag: Some(tag.to_string()), ..Default::default() }
+        let mut c = Compound { tag: Some(tag.to_string()), ..Default::default() };
+        crate::matcher::sig::set_req_for_test(&mut c);
+        c
     }
 
     /// A stack of single-letter tags; `anchor` bit 0 is set on elements whose letter is uppercase, so
@@ -436,5 +462,211 @@ mod seg_match_tests {
         }
         // the old walk needed ~28 s for ONE subject at depth 40; this whole sweep is milliseconds
         assert!(t.elapsed().as_secs() < 2, "took {:?}", t.elapsed());
+    }
+}
+
+#[cfg(test)]
+mod sig_filter_tests {
+    use super::*;
+    use crate::matcher::sig;
+    use crate::selector::Compound;
+
+    /// A compound built the way the compile step builds one: fields set, then `set_req`.
+    fn cmp(tag: Option<&str>, id: Option<&str>, classes: &[&str]) -> Compound {
+        let mut c = Compound {
+            tag: tag.map(str::to_string),
+            id: id.map(str::to_string),
+            classes: classes.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        };
+        sig::set_req_for_test(&mut c);
+        c
+    }
+
+    fn el(tag: &'static [u8], attrs: &[(&'static [u8], &'static str)]) -> OpenElem<'static> {
+        OpenElem::for_test_attrs(tag, attrs)
+    }
+
+    /// The filter may only turn a `false` into a faster `false`. Over every combination of tag / id /
+    /// class-set on both sides, plus `:not()` and `:is()` wrappers whose bits must NOT be required, the
+    /// filtered predicate must agree with the unfiltered one.
+    #[test]
+    fn filter_never_rejects_a_match() {
+        // element side: tag case, id case/absence, class lists that overlap the compound side
+        let tags: [&'static [u8]; 5] = [b"div", b"DIV", b"Div", b"span", b"a"];
+        let ids = [None, Some("Bar"), Some("bar"), Some("BAR"), Some("")];
+        let class_sets = [
+            None,
+            Some(""),
+            Some("Foo"),
+            Some("foo"),
+            Some("FOO"),
+            Some("Foo bar"),
+            Some("bar Foo baz"),
+            Some("foo Bar"),
+            Some("c1 c2 c3 c4 c5 c6 c7 c8 c9"), // a long utility-CSS-style list
+            // ASCII whitespace splits these...
+            Some("  Foo   bar  "),
+            Some("Foo\tbar\nbaz\r\nqux"),
+            // ...and not these: each is ONE token containing a space-like character.
+            Some("Foo\u{a0}bar"),  // NBSP
+            Some("Foo\u{3000}bar"), // IDEOGRAPHIC SPACE (the crawled-page case in `has_class`)
+            Some("Foo\u{b}bar"),   // U+000B, whitespace in Unicode but not in HTML
+            Some("café Foo"),
+        ];
+        // compound side: the same universe, so hits and misses both occur
+        let c_tags = [None, Some("*"), Some("div"), Some("DIV"), Some("span")];
+        let c_ids = [None, Some("Bar"), Some("bar"), Some("")];
+        let c_classes: [&[&str]; 10] = [
+            &[],
+            &["Foo"],
+            &["foo"],
+            &["FOO"],
+            &["Foo", "bar"],
+            &["bar", "Foo"],
+            &["café"],
+            // the whole-token forms of the non-ASCII-separator elements above
+            &["Foo\u{a0}bar"],
+            &["Foo\u{3000}bar"],
+            &["Foo\u{b}bar"],
+        ];
+
+        let mut compounds: Vec<Compound> = Vec::new();
+        for t in c_tags {
+            for i in c_ids {
+                for cl in c_classes {
+                    let base = cmp(t, i, cl);
+                    // `:not(<the same compound>)` — requiring its bits would invert the answer
+                    let mut neg = cmp(t, None, &[]);
+                    neg.negations.push(base.clone());
+                    sig::set_req_for_test(&mut neg);
+                    // `:is(a, b)` — an OR, so neither alternative's bits may be required
+                    let mut isg = cmp(t, None, &[]);
+                    isg.is_groups.push(vec![base.clone(), cmp(Some("span"), None, &["nope"])]);
+                    sig::set_req_for_test(&mut isg);
+                    compounds.extend([base, neg, isg]);
+                }
+            }
+        }
+
+        let mut checked = 0u64;
+        let mut filtered_out = 0u64;
+        for tag in tags {
+            for id in ids {
+                for cs in class_sets {
+                    let mut attrs: Vec<(&'static [u8], &'static str)> = Vec::new();
+                    if let Some(i) = id {
+                        attrs.push((b"id", i));
+                    }
+                    if let Some(c) = cs {
+                        attrs.push((b"class", c));
+                    }
+                    let e = el(tag, &attrs);
+                    for c in &compounds {
+                        let want = compound_matches_unfiltered(c, &e);
+                        assert_eq!(
+                            compound_matches(c, &e),
+                            want,
+                            "filter changed the answer: tag={:?} id={id:?} class={cs:?} req={:#x} \
+                             sig={:#x} compound={c:?}",
+                            std::str::from_utf8(tag),
+                            c.req,
+                            e.sig,
+                        );
+                        if !want && e.sig & c.req != c.req {
+                            filtered_out += 1;
+                        }
+                        checked += 1;
+                    }
+                }
+            }
+        }
+        // A filter that rejects nothing would pass the equality above trivially, so assert it is
+        // actually doing the work this change exists for.
+        assert!(checked > 10_000, "expected a real sweep, ran {checked}");
+        assert!(
+            filtered_out * 3 > checked,
+            "the filter rejected only {filtered_out}/{checked} pairs before any string compare"
+        );
+    }
+
+    /// The exact-comparison semantics the hash has to mirror: the TAG is case-insensitive, while `id`
+    /// and class tokens are case-SENSITIVE. Folding the wrong one of those is the false negative that
+    /// silently drops values, and it is invisible in any vector whose cases already agree.
+    #[test]
+    fn case_sensitivity_mirrors_the_predicates() {
+        let e = el(b"DIV", &[(b"class", "Foo"), (b"id", "Bar")]);
+        // mixed-case tag still matches, either way round
+        assert!(compound_matches(&cmp(Some("div"), Some("Bar"), &["Foo"]), &e));
+        assert!(compound_matches(&cmp(Some("DIV"), Some("Bar"), &["Foo"]), &e));
+        assert!(compound_matches(&cmp(Some("Div"), None, &[]), &e));
+        // wrong-case class / id still does NOT match
+        assert!(!compound_matches(&cmp(Some("DIV"), None, &["foo"]), &e));
+        assert!(!compound_matches(&cmp(Some("div"), None, &["FOO"]), &e));
+        assert!(!compound_matches(&cmp(Some("div"), Some("bar"), &[]), &e));
+        assert!(!compound_matches(&cmp(None, Some("BAR"), &[]), &e));
+        // and the signature itself must be what rejects the wrong-case cases (not just the string
+        // compare downstream) — otherwise the case rule could be wrong in the hash and never show
+        let wrong_class = cmp(Some("div"), None, &["foo"]);
+        let wrong_id = cmp(Some("div"), Some("bar"), &[]);
+        assert_ne!(e.sig & wrong_class.req, wrong_class.req);
+        assert_ne!(e.sig & wrong_id.req, wrong_id.req);
+        // the case-insensitive tag, in contrast, must NOT be rejected by the signature
+        let tag_only = cmp(Some("dIv"), None, &[]);
+        assert_eq!(e.sig & tag_only.req, tag_only.req);
+    }
+
+    /// HTML splits a class list on ASCII whitespace only, so `class="a\u{3000}b"` is ONE class and the
+    /// signature must hash that one token. A wider split would leave the element's signature without the
+    /// whole token's bits and the filter would reject a match. This fails if `class_tokens` stops being
+    /// shared with `has_class`.
+    #[test]
+    fn class_tokenizer_is_shared_with_the_signature() {
+        for sep in ['\u{a0}', '\u{3000}', '\u{b}', '\u{2003}'] {
+            let ws: &'static str = Box::leak(format!("a{sep}b").into_boxed_str());
+            let e = el(b"div", &[(b"class", ws)]);
+            let whole = cmp(None, None, &[ws]);
+            assert!(
+                compound_matches(&whole, &e),
+                "the one-token class {ws:?} was filtered out (separator {sep:?} split the signature \
+                 but not the predicate)"
+            );
+            assert_eq!(e.sig & whole.req, whole.req);
+            // and the halves a Unicode split would have produced must NOT match, on both paths
+            for half in ["a", "b"] {
+                let c = cmp(None, None, &[half]);
+                assert!(!compound_matches(&c, &e), "half-token {half:?} matched {ws:?}");
+                assert!(!compound_matches_unfiltered(&c, &e));
+            }
+        }
+    }
+
+    /// `req` must come only from the compound's own positive tag/id/classes. `*` contributes nothing,
+    /// and neither do the parts of the compound whose semantics the filter cannot represent.
+    #[test]
+    fn req_covers_only_positive_identity() {
+        use crate::selector::AttrPred;
+        const ALL_ON: sig::Opts = sig::Opts { tag: true, class: true };
+        assert_eq!(cmp(None, None, &[]).req, 0);
+        assert_eq!(cmp(Some("*"), None, &[]).req, 0);
+        assert_ne!(cmp(Some("div"), None, &[]).req, 0);
+
+        // `:not(.x)` / `:is(.x)` / `[href^=/]` on a universal compound: nothing to require
+        let mut neg = cmp(Some("*"), None, &[]);
+        neg.negations.push(cmp(None, None, &["x"]));
+        assert_eq!(sig::compound_req(&neg, ALL_ON), 0);
+        let mut isg = cmp(Some("*"), None, &[]);
+        isg.is_groups.push(vec![cmp(None, None, &["x"]), cmp(None, None, &["y"])]);
+        assert_eq!(sig::compound_req(&isg, ALL_ON), 0);
+        let mut at = cmp(Some("*"), None, &[]);
+        at.attrs.push(AttrPred::Prefix("href".into(), "/".into()));
+        assert_eq!(sig::compound_req(&at, ALL_ON), 0);
+
+        // ...but a nested compound still gets its OWN req, for its own recursive call
+        let mut neg2 = cmp(Some("*"), None, &[]);
+        neg2.negations.push(cmp(None, None, &["x"]));
+        sig::set_req_for_test(&mut neg2);
+        assert_eq!(neg2.req, 0);
+        assert_ne!(neg2.negations[0].req, 0);
     }
 }

--- a/src/matcher/mod.rs
+++ b/src/matcher/mod.rs
@@ -38,6 +38,7 @@ mod compile;
 mod frame;
 mod deferred;
 mod matching;
+mod sig;
 
 use compile::{
     any_has, any_reverse, any_text_pred, deferrable_has, deferrable_reverse,
@@ -122,6 +123,17 @@ pub struct OpenElem<'a> {
     /// `<b>` but not an open `<em>`.
     scid: u8,
     attrs: Vec<(&'a [u8], Cow<'a, str>)>, // only "interesting" attrs; value entity-decoded (lazy Cow)
+    /// This element's identity signature: the Bloom bits of its tag, `id`, and class tokens, built
+    /// once at open and ANDed against each compound's `req` before any string comparison (see [`sig`]).
+    /// 0 when the schema requires no bits at all (`!wants.any()`), which makes the test a no-op.
+    ///
+    /// INVARIANT: this is built from the MATERIALIZED `attrs`, which hold only the schema's
+    /// "interesting" set — so it can carry class/id bits only for a schema that asked for those
+    /// attributes. `collect_interesting` adds `class`/`id` whenever ANY compiled compound references
+    /// them, and a `req` can only carry class/id bits if some compound did, so whenever a `req` demands
+    /// them this signature was built from the same data. Materializing fewer attributes than the
+    /// compounds reference would turn this filter into silently dropped values.
+    pub(super) sig: u64,
     matched: u128, // bit k: this element is a subject match for member-selector k (≤128 members)
     matched_tree: u128, // OR of `matched` over this element and its open ancestors
     text_cols: u128, // flat output columns that want a text event directly under this element
@@ -133,59 +145,148 @@ pub struct OpenElem<'a> {
     start: usize,  // byte offset of this element's `<` (for raw-source outer-HTML capture)
     cap_cols: u128, // output columns wanting this element's raw source (OuterHtml terminal)
     insts: usize,  // number of group instances this element opened (popped when it closes)
-    gcaps: Vec<(u64, usize)>, // grouped outer-HTML captures: (instance seq, sub) this element feeds
     // 1-based sibling positions, set at open from the parent's counters (0 = not tracked). Read by the
     // matching kernel for `:nth-child`/`:nth-of-type` and XPath `[N]`. `of_type_index` is populated only
     // for tags that a positional selector references (see `CompiledSchema::positional_tags`).
     pub(super) child_index: u32,
     pub(super) of_type_index: u32,
-    // Reverse-positional (`:last-*`/`:only-*`) bookkeeping — all empty/zero unless `has_reverse`.
+    // Reverse-positional (`:last-*`/`:only-*`) bookkeeping — all zero unless `has_reverse`.
     rev_subj: u128, // bit r: this element is a PROVISIONAL subject for reverse-entry r (routes captures)
-    rev_buf: Vec<(u32, usize, String)>, // (rev-entry, offset, value) captured while this el is a subject
-    rev_pending: Vec<RevPend>, // candidates promoted from this element's children, resolved at its close
-    // `:has()` bookkeeping — all empty/zero unless `has_has`. Resolved at THIS element's own close
+    // `:has()` bookkeeping — all zero unless `has_has`. Resolved at THIS element's own close
     // (its descendants are all known then), unlike reverse (resolved at the parent's close).
     has_subj: u128, // bit h: this element is a PROVISIONAL subject for has-entry h (structural match)
     has_done: u128, // bit h: a qualifying descendant/child was found -> the `:has(h)` constraint holds
-    has_buf: Vec<(u32, usize, String)>, // (has-entry, offset, value) captured while this el is a subject
-    // Text-content predicate bookkeeping — empty/zero unless `has_text_pred`. Predicate evaluation is
-    // streaming and bounded by the needle length; only prospective terminal values are retained.
+    // Text-content predicate bookkeeping — zero unless `has_text_pred`.
     txt_subj: u128,
+    /// The buffers those tiers fill, allocated ONLY for an element that actually feeds one — see
+    /// [`ColdState`], which exists because this struct is memcpy'd per element and they are empty on
+    /// almost every one.
+    cold: Option<Box<ColdState>>,
+}
+
+/// Per-element buffers that only the DEFERRED tiers (`:has()`, reverse position, text predicates) and
+/// grouped raw-source captures ever write, boxed out of [`OpenElem`]: pushing an element memcpies the
+/// whole struct, and these six `Vec`s are 144 bytes that are empty on almost every element of almost
+/// every page. One `Option<Box<_>>` instead keeps `OpenElem` at 240 bytes and costs an allocation only
+/// where a `Vec` would have allocated anyway.
+///
+/// Cold means "written by few elements", not "read rarely": the close path reads these on every element
+/// while a deferred tier is live, so reads go through [`OpenElem::cold`], which returns a shared empty
+/// instance. Only [`OpenElem::cold_mut`] creates the box.
+#[derive(Default)]
+struct ColdState {
+    gcaps: Vec<(u64, usize)>, // grouped outer-HTML captures: (instance seq, sub) this element feeds
+    rev_buf: Vec<(u32, usize, String)>, // (rev-entry, offset, value) captured while this el is a subject
+    rev_pending: Vec<RevPend>, // candidates promoted from this element's children, resolved at its close
+    has_buf: Vec<(u32, usize, String)>, // (has-entry, offset, value) captured while this el is a subject
+    // Predicate evaluation is streaming and bounded by the needle length; only prospective terminal
+    // values are retained.
     txt_states: Vec<TextMatchState>,
     txt_emit: Vec<(u32, usize, String)>, // (entry, offset, prospective attr/direct-text value)
 }
 
+/// Read-side stand-in for an element that never wrote cold state. `Vec::new` is `const`, so this costs
+/// no allocation and lets [`OpenElem::cold`] be infallible without the box existing.
+static NO_COLD: ColdState = ColdState {
+    gcaps: Vec::new(),
+    rev_buf: Vec::new(),
+    rev_pending: Vec::new(),
+    has_buf: Vec::new(),
+    txt_states: Vec::new(),
+    txt_emit: Vec::new(),
+};
+
 impl<'a> OpenElem<'a> {
-    /// A bare element for matching-kernel tests: a tag, no attributes, no bookkeeping. Only the
-    /// `matching` unit tests build elements directly; the scan always goes through `start_tag`.
-    #[cfg(test)]
-    pub(super) fn for_test(tag: &'a [u8]) -> Self {
-        OpenElem {
+    /// A freshly opened element: the tokenizer's facts, plus the signature DERIVED from the
+    /// materialized `attrs`. The only constructor — the scan and the unit-test builders both go through
+    /// it, so a derived field cannot be set at one site and forgotten at the other. `wants` is what the
+    /// schema's compounds require (see [`sig::Wants`]); when they require nothing, every `req` is 0 and
+    /// the signature would filter nothing, so it isn't built.
+    fn open(
+        tag: &'a [u8], scid: u8, attrs: Vec<(&'a [u8], Cow<'a, str>)>, start: usize, wants: sig::Wants,
+    ) -> Self {
+        let mut e = OpenElem {
             tag,
-            scid: 0,
-            attrs: Vec::new(),
+            scid,
+            attrs,
+            sig: 0,
             matched: 0,
             matched_tree: 0,
             text_cols: 0,
             seen: 0,
             prev: 0,
             anchor: 0,
-            start: 0,
+            start,
             cap_cols: 0,
             insts: 0,
-            gcaps: Vec::new(),
             child_index: 0,
             of_type_index: 0,
             rev_subj: 0,
-            rev_buf: Vec::new(),
-            rev_pending: Vec::new(),
             has_subj: 0,
             has_done: 0,
-            has_buf: Vec::new(),
             txt_subj: 0,
-            txt_states: Vec::new(),
-            txt_emit: Vec::new(),
+            cold: None,
+        };
+        if wants.any() {
+            e.sig = e.signature(wants);
         }
+        e
+    }
+
+    /// This element's Bloom signature, over exactly the sources `compound_matches` compares
+    /// positively — and only the KINDS of source some compound requires (see [`sig::Wants`]: a schema
+    /// with no class-led compound must not pay to hash every element's class list).
+    ///
+    /// Built through the element's OWN accessors (`attr`, `class_tokens`) rather than by re-reading
+    /// `attrs`, so "which `id`, which `class` attribute, which tokens" cannot answer differently here
+    /// than in the predicate the filter guards — including for markup that repeats the attribute, where
+    /// both sides take the first.
+    fn signature(&self, wants: sig::Wants) -> u64 {
+        let mut s = if wants.tag { sig::tag_bits(self.tag) } else { 0 };
+        if wants.id {
+            if let Some(id) = self.attr("id") {
+                s |= sig::id_bits(id.as_bytes());
+            }
+        }
+        if wants.class {
+            for cls in self.class_tokens() {
+                s |= sig::class_bits(cls.as_bytes());
+            }
+        }
+        s
+    }
+
+    /// A bare element for matching-kernel tests: a tag, no attributes, no bookkeeping. Only the
+    /// `matching` unit tests build elements directly; the scan always goes through `start_tag`.
+    #[cfg(test)]
+    pub(super) fn for_test(tag: &'a [u8]) -> Self {
+        Self::open(tag, 0, Vec::new(), 0, sig::Wants::all())
+    }
+
+    /// A test element WITH attributes (`&'static str` values, borrowed like the scan's clean-UTF-8
+    /// case), so the class/id-dependent predicates and the signature can be exercised directly.
+    #[cfg(test)]
+    pub(super) fn for_test_attrs(tag: &'a [u8], attrs: &[(&'a [u8], &'a str)]) -> Self {
+        Self::open(
+            tag,
+            0,
+            attrs.iter().map(|&(n, v)| (n, Cow::Borrowed(v))).collect(),
+            0,
+            sig::Wants::all(),
+        )
+    }
+
+    /// The cold buffers for reading: the element's own if it ever wrote one, else the shared empty
+    /// [`NO_COLD`]. Infallible and allocation-free, so a close path can read these unconditionally.
+    fn cold(&self) -> &ColdState {
+        self.cold.as_deref().unwrap_or(&NO_COLD)
+    }
+
+    /// The cold buffers for writing, created on first use. Every call site is a tier that is about to
+    /// push a captured value or a predicate state, so the allocation lands only on elements that were
+    /// going to allocate a `Vec` anyway.
+    fn cold_mut(&mut self) -> &mut ColdState {
+        self.cold.get_or_insert_with(Box::default)
     }
 
     pub(super) fn attr(&self, name: &str) -> Option<&str> {
@@ -194,14 +295,23 @@ impl<'a> OpenElem<'a> {
             .find(|(n, _)| n.eq_ignore_ascii_case(name.as_bytes()))
             .map(|(_, v)| v.as_ref())
     }
-    /// ASCII whitespace, NOT `split_whitespace`'s Unicode set — HTML splits a class list on space, tab,
-    /// LF, FF and CR and nothing else. Splitting on the Unicode set invented classes: a crawled page
-    /// whose `class="ctsListWrap fadein　clearfix"` separates two of them with an IDEOGRAPHIC SPACE
-    /// (U+3000, ordinary in Japanese markup) has one token `fadein　clearfix`, and the engine matched
-    /// both `.fadein` and `.clearfix` on it — elements a scraper's selector should never have seen.
-    /// Same for NBSP, the em space, and U+000B, which is not ASCII whitespace in HTML.
+    /// This element's `class=` tokens, in source order. ASCII whitespace, NOT `split_whitespace`'s
+    /// Unicode set — HTML splits a class list on space, tab, LF, FF and CR and nothing else. Splitting
+    /// on the Unicode set invented classes: a crawled page whose `class="ctsListWrap fadein　clearfix"`
+    /// separates two of them with an IDEOGRAPHIC SPACE (U+3000, ordinary in Japanese markup) has one
+    /// token `fadein　clearfix`, and the engine matched both `.fadein` and `.clearfix` on it — elements
+    /// a scraper's selector should never have seen. Same for NBSP, the em space, and U+000B, which is
+    /// not ASCII whitespace in HTML.
+    ///
+    /// ONE tokenizer, read by both the membership predicate below and [`Self::signature`]. The split
+    /// rule is part of the predicate the signature filter guards, so a second copy of it is a
+    /// false-negative generator: tokens hashed under a wider split than the predicate compares would
+    /// let a matching element be rejected before any string comparison ran (see `sig`).
+    fn class_tokens(&self) -> impl Iterator<Item = &str> {
+        self.attr("class").unwrap_or_default().split_ascii_whitespace()
+    }
     pub(super) fn has_class(&self, cls: &str) -> bool {
-        self.attr("class").is_some_and(|v| v.split_ascii_whitespace().any(|t| t == cls))
+        self.class_tokens().any(|t| t == cls)
     }
 }
 
@@ -497,6 +607,55 @@ fn to_segments(sel: &Selector) -> (Vec<Segment>, Vec<bool>) {
 }
 
 
+/// A one-sided reject for attribute MATERIALIZATION, the same shape as the signature filter one level
+/// down: a 64-bit set of the (first byte, length) pairs the schema's "interesting" attribute names have.
+///
+/// Every raw attribute of every element used to be compared against every interesting name, so the cost
+/// was `attrs × interesting` `eq_ignore_ascii_case` calls per element — and it grew with schema size
+/// exactly where it hurts, since a 32-field attribute-led schema names about 30 attributes while a real
+/// element carries half a dozen the schema never asked for. One bit test rejects those.
+///
+/// One-sided in the same direction and for the same reason as `sig`: a set bit is NECESSARY, never
+/// sufficient, so a survivor still faces the exact comparison. A false negative here would silently drop
+/// an attribute the matcher needs — and would also silently weaken the signature filter, whose class/id
+/// bits are built from the materialized set.
+///
+/// One word and one test: a pre-filter has to be cheaper than the scan it guards for the schemas that
+/// CANNOT use it, and a two-name scan is one length comparison. `OpenElem::attr` still scans the
+/// materialized list by name, but that list holds only the interesting attributes an element actually
+/// carries — 0.33–1.40 per element over the benchmark pools, the same at 8 selectors as at 32 — so
+/// interning those names to slots has nothing left to win.
+#[derive(Clone, Copy, Default)]
+struct AttrGate(u64);
+
+impl AttrGate {
+    /// The bit an attribute name claims, from its ASCII-lowercased first byte and its length — the two
+    /// facts available without reading the name. Lowercased because the exact comparison is
+    /// case-insensitive, so `CLASS` and `class` must claim the same bit. Everything folds mod 64; a
+    /// collision only costs the exact comparison that always ran.
+    fn bit(name: &[u8]) -> u64 {
+        let Some(&b0) = name.first() else { return 0 };
+        let h = (b0.to_ascii_lowercase() as u32).wrapping_mul(37) ^ (name.len() as u32).wrapping_mul(11);
+        1u64 << (h & 63)
+    }
+
+    /// `None` below this: with one or two interesting names the scan the gate guards is already one
+    /// length comparison, and gating it measured ~1.5% worse. The name count is a proxy — what actually
+    /// decides the trade is the fraction of a PAGE's attributes the schema ignores, which is unknowable
+    /// at compile time. Measured on an attribute-heavy page: 4 names −4.1%, 8 −5.4%, 16 −7.7%, 30 −9.5%.
+    const MIN_NAMES: usize = 4;
+
+    fn build(interesting: &[Box<str>]) -> Option<AttrGate> {
+        (interesting.len() >= Self::MIN_NAMES)
+            .then(|| AttrGate(interesting.iter().fold(0, |acc, n| acc | Self::bit(n.as_bytes()))))
+    }
+
+    /// Could `name` be interesting? `false` is proof it is not.
+    fn admits(&self, name: &[u8]) -> bool {
+        self.0 & Self::bit(name) != 0
+    }
+}
+
 /// A schema compiled ONCE, reusable across any number of pages. It holds only page-independent state —
 /// the lowered selector entries, group specs, and the derived interesting-attribute set / fast-path
 /// flags — so a caller that runs the same selectors over many responses (the `Page`/`FrostPage` usage
@@ -505,6 +664,9 @@ fn to_segments(sel: &Selector) -> (Vec<Segment>, Vec<bool>) {
 pub struct CompiledSchema {
     entries: Vec<CSel>,
     interesting: Vec<Box<str>>, // attr names any selector references (lowercased)
+    // One-sided reject so an attribute no selector references costs one bit test instead of a scan.
+    // `None` when the schema names too few attributes for that to pay (see `AttrGate::MIN_NAMES`).
+    attr_gate: Option<AttrGate>,
     has_outer: bool,            // any OuterHtml selector (flat OR grouped)? (skips capture bookkeeping otherwise)
     has_sibling: bool,          // any multi-segment (sibling `+`/`~`) entry? (skips the per-element anchor pass otherwise)
     groups: Vec<GroupSpec>,     // Many/One sub-field schemas
@@ -531,6 +693,11 @@ pub struct CompiledSchema {
     // deferred (preceding-sibling-predicate) boundary fires only at its `C`'s close, not at open. All
     // ones when no Case-B selector is compiled — the hot sibling path is then unchanged.
     trig_immediate_mask: u64,
+    // What the compiled compounds require of an element signature (see `sig::Wants`) — derived by the
+    // same walk that fills the `req`s, so the two cannot disagree. That is the whole safety argument
+    // for letting the scan build LESS than a full signature: a kind of bit no `req` asks for can be
+    // left out, but one that is asked for must always be present.
+    wants: sig::Wants,
 }
 
 /// Per-page scan state, borrowing a compiled [`CompiledSchema`] and the document bytes. One is built,
@@ -967,8 +1134,58 @@ impl CompiledSchema {
         let has_ns_element = entries
             .iter()
             .any(|cs| matches!(&cs.terminal, Terminal::NormalizeSpace(inner) if matches!(**inner, Terminal::OuterHtml)));
+
+        // Signature requirements (see `sig`): ONE pass over every tier that holds compiled compounds,
+        // filling each `Compound::req` and accumulating what the scan must build (`sig::Wants`). Both
+        // jobs in the same walk on purpose — a tier missing here keeps `req == 0` (its filter is a
+        // no-op) and adds nothing to `wants`, so an omission costs speed and can never drop a match.
+        // Tail schemas are themselves `CompiledSchema`s, already finalized by their own `compile` call.
+        fn seg_reqs(seg: &mut Segment, o: sig::Opts, w: &mut sig::Wants) {
+            for c in &mut seg.parts {
+                sig::set_req(c, o, w);
+            }
+        }
+        // Are tag / class bits worth their per-element hash for THIS schema (see `sig::BITS_MIN`)? The
+        // count is over the source selectors, which is a superset of what compiles — a cost estimate,
+        // not a correctness input: `opts` drives the element signature and every `req` alike, so a
+        // miscount can only buy or forgo the optimization.
+        let (tag_tests, class_tests) = queries
+            .iter()
+            .flatten()
+            .chain(groups.iter().flat_map(|(c, subs)| c.iter().chain(subs.iter().flatten())))
+            .flat_map(|sel| sel.parts.iter())
+            .map(sig::tests)
+            .fold((0, 0), |(t, c), (dt, dc)| (t + dt, c + dc));
+        let opts = sig::Opts { tag: tag_tests >= sig::BITS_MIN, class: class_tests >= sig::BITS_MIN };
+        let mut wants = sig::Wants::default();
+        for cs in &mut entries {
+            for seg in &mut cs.segments {
+                seg_reqs(seg, opts, &mut wants);
+            }
+        }
+        for g in &mut group_specs {
+            for sub in &mut g.subs {
+                if let Some(seg) = &mut sub.seg {
+                    seg_reqs(seg, opts, &mut wants);
+                }
+            }
+        }
+        for re in &mut reverse_entries {
+            seg_reqs(&mut re.seg, opts, &mut wants);
+        }
+        for he in &mut has_entries {
+            seg_reqs(&mut he.seg, opts, &mut wants);
+            // the `:has()` inner compound is matched by its own `compound_matches` call, against
+            // descendants, so it is a filterable question in its own right
+            sig::set_req(&mut he.has.inner, opts, &mut wants);
+        }
+        for te in &mut text_entries {
+            seg_reqs(&mut te.seg, opts, &mut wants);
+        }
+
         CompiledSchema {
             n_flat_cols: queries.len(),
+            attr_gate: AttrGate::build(&interesting),
             n_groups: group_specs.len(),
             entries,
             interesting,
@@ -988,6 +1205,7 @@ impl CompiledSchema {
             text_entries,
             tail_schemas,
             trig_immediate_mask,
+            wants,
         }
     }
 
@@ -1112,7 +1330,7 @@ impl<'a> Matcher<'a> {
             cols &= cols - 1;
             self.captures.push((e.start, end, Dest::Flat(col)));
         }
-        for &(seq, sub) in &e.gcaps {
+        for &(seq, sub) in &e.cold().gcaps {
             self.captures.push((e.start, end, Dest::Grouped { seq, sub }));
         }
         for _ in 0..e.insts {
@@ -1123,11 +1341,11 @@ impl<'a> Matcher<'a> {
         // its children's totals are now known (its child counter frame is the last `stride` block of
         // `self.pos`, still present until the truncate below). Commit each candidate whose from-end
         // position satisfies the entry (see `reverse_matches`) to the deferred `pending` output.
-        if self.schema.has_reverse && !e.rev_pending.is_empty() {
+        if self.schema.has_reverse && !e.cold().rev_pending.is_empty() {
             let stride = 1 + self.schema.positional_tags.len();
             let base = self.pos.len() - stride;
             let total_children = self.pos[base];
-            for pend in &e.rev_pending {
+            for pend in &e.cold().rev_pending {
                 let re = &self.schema.reverse_entries[pend.entry as usize];
                 let total = match re.of_type_tag {
                     Some(j) => self.pos[base + 1 + j],
@@ -1167,6 +1385,7 @@ impl<'a> Matcher<'a> {
                 let (of_type, single_slot) = (re.rev.of_type, re.single_slot);
                 let idx = if of_type { e.of_type_index } else { e.child_index };
                 let vals: Vec<(usize, String)> = e
+                    .cold()
                     .rev_buf
                     .iter()
                     .filter(|(er, _, _)| *er == r)
@@ -1174,7 +1393,7 @@ impl<'a> Matcher<'a> {
                     .collect();
                 let cand = RevCand { idx, vals, span: (e.start, end) };
                 let target = match self.stack.last_mut() {
-                    Some(parent) => &mut parent.rev_pending,
+                    Some(parent) => &mut parent.cold_mut().rev_pending,
                     None => &mut self.doc_rev_pending,
                 };
                 match target.iter_mut().find(|p| p.entry == r) {
@@ -1217,7 +1436,7 @@ impl<'a> Matcher<'a> {
                     let val = decode::raw_source(&self.input[e.start..end], self.enc);
                     self.pending.push((he.col, e.start, val));
                 } else {
-                    for (eh, off, v) in &e.has_buf {
+                    for (eh, off, v) in &e.cold().has_buf {
                         if *eh == h {
                             self.pending.push((he.col, *off, v.clone()));
                         }
@@ -1235,6 +1454,7 @@ impl<'a> Matcher<'a> {
                 s &= s - 1;
                 let te = &self.schema.text_entries[t as usize];
                 let holds = e
+                    .cold()
                     .txt_states
                     .iter()
                     .find(|state| state.entry == t)
@@ -1262,7 +1482,7 @@ impl<'a> Matcher<'a> {
                         self.pending.push((te.col, e.start, val));
                     }
                     Terminal::Attr { .. } | Terminal::Text { .. } => {
-                        for (et, off, v) in &e.txt_emit {
+                        for (et, off, v) in &e.cold().txt_emit {
                             if *et == t {
                                 self.pending.push((te.col, *off, v.clone()));
                             }
@@ -1379,7 +1599,15 @@ impl<'a> Matcher<'a> {
         (self.results, grouped)
     }
 
+    /// Does any selector reference this attribute? Gated by [`AttrGate`] first, which rejects the
+    /// attributes a schema never asked about — the majority on a real page — without touching the name
+    /// list. A survivor still gets the exact case-insensitive comparison, so the answer is unchanged.
     fn is_interesting(&self, name: &[u8]) -> bool {
+        if let Some(gate) = &self.schema.attr_gate {
+            if !gate.admits(name) {
+                return false;
+            }
+        }
         self.schema.interesting.iter().any(|x| x.as_bytes().eq_ignore_ascii_case(name))
     }
 }
@@ -1537,7 +1765,7 @@ impl<'a> Matcher<'a> {
             }
         }
         self.stack[top].rev_subj = subj;
-        self.stack[top].rev_buf.extend(caps);
+        self.stack[top].cold_mut().rev_buf.extend(caps);
     }
 
     /// Capture this text node for any reverse entry whose (attached) `::text` subject is `stack[top]`.
@@ -1563,7 +1791,7 @@ impl<'a> Matcher<'a> {
         while w != 0 {
             let r = w.trailing_zeros();
             w &= w - 1;
-            self.stack[top].rev_buf.push((r, off, out.clone()));
+            self.stack[top].cold_mut().rev_buf.push((r, off, out.clone()));
         }
     }
 
@@ -1589,7 +1817,7 @@ impl<'a> Matcher<'a> {
             }
         }
         self.stack[top].has_subj = subj;
-        self.stack[top].has_buf.extend(caps);
+        self.stack[top].cold_mut().has_buf.extend(caps);
     }
 
     /// If `stack[top]` matches the `:has` INNER compound of some entry, mark that entry's `has_done` bit
@@ -1643,7 +1871,7 @@ impl<'a> Matcher<'a> {
         while w != 0 {
             let h = w.trailing_zeros();
             w &= w - 1;
-            self.stack[top].has_buf.push((h, off, out.clone()));
+            self.stack[top].cold_mut().has_buf.push((h, off, out.clone()));
         }
     }
 
@@ -1670,8 +1898,14 @@ impl<'a> Matcher<'a> {
             self.txt_open += 1;
         }
         self.stack[top].txt_subj = subj;
-        self.stack[top].txt_states.extend(states);
-        self.stack[top].txt_emit.extend(emit);
+        // `text_open` runs for EVERY element while the schema has a text-predicate entry, so touching
+        // `cold_mut()` unconditionally here would allocate a box per element and undo the point of
+        // boxing. Only a provisional subject has anything to store.
+        if !states.is_empty() || !emit.is_empty() {
+            let cold = self.stack[top].cold_mut();
+            cold.txt_states.extend(states);
+            cold.txt_emit.extend(emit);
+        }
     }
 
     /// Stream this text node through every open predicate state it belongs to. Only direct text values
@@ -1684,9 +1918,10 @@ impl<'a> Matcher<'a> {
             }
             let direct = e == top;
             let mut emit_entries = Vec::new();
-            {
-                let elem = &mut self.stack[e];
-                for state in &mut elem.txt_states {
+            // A subject's states were created at its open, so the box exists whenever there is anything
+            // to update; reading through the Option avoids creating one for a subject with no state.
+            if let Some(cold) = self.stack[e].cold.as_deref_mut() {
+                for state in &mut cold.txt_states {
                     let te = &self.schema.text_entries[state.entry as usize];
                     state.update(&te.pred, &out, direct);
                     if direct && te.tail.is_none() && matches!(te.terminal, Terminal::Text { subtree: false }) {
@@ -1695,7 +1930,7 @@ impl<'a> Matcher<'a> {
                 }
             }
             for entry in emit_entries {
-                self.stack[e].txt_emit.push((entry, off, out.clone()));
+                self.stack[e].cold_mut().txt_emit.push((entry, off, out.clone()));
             }
         }
     }
@@ -1883,32 +2118,11 @@ impl<'a> TokenSink<'a> for Matcher<'a> {
                 attrs.push((an, value));
             }
         }
-        self.stack.push(OpenElem {
-            tag: name,
-            scid,
-            attrs,
-            matched: 0,
-            matched_tree: 0,
-            text_cols: 0,
-            seen: 0,
-            prev: 0,
-            anchor: 0,
-            start: span_start,
-            cap_cols: 0,
-            insts: 0,
-            gcaps: Vec::new(),
-            child_index: 0,
-            of_type_index: 0,
-            rev_subj: 0,
-            rev_buf: Vec::new(),
-            rev_pending: Vec::new(),
-            has_subj: 0,
-            has_done: 0,
-            has_buf: Vec::new(),
-            txt_subj: 0,
-            txt_states: Vec::new(),
-            txt_emit: Vec::new(),
-        });
+        // The element's signature is built from the MATERIALIZED attributes only. That is sound because
+        // `collect_interesting` adds `class`/`id` to the interesting set whenever any compiled compound
+        // references them, so a `req` carrying class/id bits implies this element's `sig` saw the same
+        // attributes; a schema referencing neither leaves both at 0 and the filter idle.
+        self.stack.push(OpenElem::open(name, scid, attrs, span_start, self.schema.wants));
         let top = self.stack.len() - 1;
         // Assign this element's 1-based sibling positions from its parent's running counts, BEFORE
         // `eval` (positional compounds read them). Only when the schema uses positions.
@@ -1995,7 +2209,7 @@ impl<'a> TokenSink<'a> for Matcher<'a> {
                     if matches!(sub.terminal, Terminal::OuterHtml)
                         && sub_hits(&sub.seg, false, &self.stack, top, depth)
                     {
-                        self.stack[top].gcaps.push((seq, sub_idx));
+                        self.stack[top].cold_mut().gcaps.push((seq, sub_idx));
                     }
                 }
             }
@@ -2362,5 +2576,187 @@ mod deferred_state_tests {
         assert!(state.holds(&pred));
         state.update(&pred, "!", false);
         assert!(!state.holds(&pred));
+    }
+}
+
+#[cfg(test)]
+mod sig_wants_tests {
+    use super::*;
+
+    fn schema(queries: &[&str]) -> CompiledSchema {
+        let members: Vec<Vec<Selector>> =
+            queries.iter().map(|q| crate::selector::parse_list(q)).collect();
+        CompiledSchema::compile(&members, &[])
+    }
+
+    fn wants(queries: &[&str]) -> sig::Wants {
+        schema(queries).wants
+    }
+
+    /// `wants` decides how much of an element signature the scan builds, so it must be live for the
+    /// schemas that can use one and idle for the schemas that cannot. It is derived from the same walk
+    /// that sets the `req`s, so this also witnesses that the walk reaches each tier: a tier it skipped
+    /// would leave a schema that clearly requires bits reporting nothing wanted.
+    #[test]
+    fn wants_is_live_exactly_when_some_compound_requires_bits() {
+        assert!(wants(&[".price::text", ".title::text"]).any());
+        assert!(wants(&["div::text", "p::text"]).any());
+        assert!(wants(&["#main a::attr(href)"]).any());
+        assert!(wants(&["li.card:last-child span.price::text"]).any()); // deferred reverse tier
+        assert!(wants(&["div.box:has(a.deep)::text"]).any()); // deferred `:has` tier
+        // a universal selector requires nothing, so the whole signature machinery stays off
+        assert!(!wants(&["*::text"]).any());
+        assert!(!wants(&["::text"]).any());
+        assert!(!wants(&[]).any());
+    }
+
+    /// The per-KIND flags are the licence to leave bits out of an element's signature, so each must be
+    /// set whenever ANY compound — including one nested in `:not()`/`:is()`, or a `:has()` inner, or a
+    /// grouped sub-field — could ask `has_class`/`attr("id")` about it. A flag that is off while some
+    /// `req` carries that kind of bit is the one way this filter drops a value. Cases meant to be ON
+    /// carry two tests of their kind, so `sig::BITS_MIN` isn't what they measure — the two cases that DO
+    /// measure it say so.
+    #[test]
+    fn per_kind_flags_cover_every_compound_that_asks() {
+        assert!(!wants(&["div::text", "p::text"]).class);
+        assert!(!wants(&["div::text", "p::text"]).id);
+        assert!(wants(&["div::text", "p::text"]).tag);
+        // one test of a kind can't amortize hashing it (`sig::BITS_MIN`), so that kind stays off
+        assert!(!wants(&["div::text"]).tag);
+        assert!(!wants(&[".price::text"]).class);
+        assert!(wants(&[".price::text", ".title::text"]).class);
+        assert!(wants(&["#main::text"]).id);
+        assert!(wants(&["div:not(.skip).x::text"]).class); // negated class: still asked at match time
+        assert!(wants(&["div:is(.a, .b)::text"]).class);
+        assert!(wants(&["div:not(#skip)::text"]).id);
+        assert!(wants(&["div.x:has(.deep)::text"]).class); // `:has` inner, matched against descendants
+        assert!(wants(&["li:last-child.price.sale::text"]).class); // deferred reverse tier
+    }
+    /// A deferred entry whose value comes from a DESCENDANT splits into a prefix (matched in the main
+    /// scan) and a TAIL sub-schema (run over the winner's span). The class-led part of
+    /// `li:last-child span.price.sale::text` lives in the tail, so the main schema legitimately wants no
+    /// class bits — but the tail must want them, since it is the schema whose compounds ask `has_class`.
+    /// Each tail is compiled in its own right, which is what makes that automatic.
+    #[test]
+    fn a_deferred_tail_carries_its_own_wants() {
+        let sch = schema(&["li:last-child span.price.sale::text"]);
+        assert!(sch.wants.any() && !sch.wants.class, "prefix is `li:last-child`, no class");
+        let tail = &sch.tail_schemas[0].schema;
+        assert!(tail.wants.class, "the tail's `.price.sale` compound would never be filtered");
+        assert_ne!(tail.entries[0].segments[0].parts[0].req, 0);
+    }
+
+    /// Grouped containers and sub-fields are their own tier; a sub-field's compounds are matched by the
+    /// same `compound_matches`, so they must be walked too.
+    #[test]
+    fn grouped_tier_is_walked() {
+        let subs = vec![Some(crate::selector::parse_list(".price::text").remove(0))];
+        let container = Some(crate::selector::parse_list("div.card").remove(0));
+        let sch = CompiledSchema::compile(&[], &[(container, subs)]);
+        assert!(sch.wants.any());
+        assert!(sch.wants.class, "a grouped sub-field's class token was not accounted for");
+        let sub_seg = sch.groups[0].subs[0].seg.as_ref().expect("single-segment sub");
+        assert_ne!(sub_seg.parts[0].req, 0, "sub-field compound never got its req");
+        assert_ne!(sch.entries[0].segments[0].parts[0].req, 0, "container never got its req");
+    }
+}
+
+#[cfg(test)]
+mod attr_gate_tests {
+    use super::AttrGate;
+
+    /// The gate may only ever turn a `false` into a faster `false`. Swept over a spread of interesting
+    /// sets crossed with the attribute names real markup carries, comparing the gate's verdict against
+    /// the exact comparison it guards: whenever the exact answer is YES, the gate must admit.
+    #[test]
+    fn admits_everything_the_exact_comparison_would_match() {
+        let sets: [&[&str]; 6] = [
+            &["class"],
+            &["class", "id"],
+            &["href", "src", "data-sku"],
+            &["class", "id", "href", "src", "alt", "value", "content", "data-price"],
+            &[],
+            &["a", "averyveryverylongattributenamethatgoeswellpastsixtythreecharacterslong"],
+        ];
+        let names: [&[u8]; 22] = [
+            b"class", b"CLASS", b"Class", b"id", b"ID", b"href", b"HREF", b"src", b"alt", b"role",
+            b"aria-label", b"data-sku", b"DATA-SKU", b"data-index", b"value", b"content", b"itemprop",
+            b"loading", b"width", b"a", b"averyveryverylongattributenamethatgoeswellpastsixtythreecharacterslong",
+            b"",
+        ];
+        let mut admitted_but_no_match = 0u32;
+        let mut rejected = 0u32;
+        for set in sets {
+            let owned: Vec<Box<str>> = set.iter().map(|s| (*s).into()).collect();
+            let gate = AttrGate::build(&owned);
+            for name in names {
+                let admits = |n: &[u8]| gate.as_ref().is_none_or(|g| g.admits(n));
+                let exact = owned.iter().any(|x| x.as_bytes().eq_ignore_ascii_case(name));
+                if exact {
+                    assert!(
+                        admits(name),
+                        "gate rejected {:?}, which set {set:?} does reference",
+                        std::str::from_utf8(name)
+                    );
+                } else if admits(name) {
+                    admitted_but_no_match += 1; // a false positive: allowed, costs only the exact scan
+                } else {
+                    rejected += 1;
+                }
+            }
+        }
+        // and it must actually reject, or it is not doing the job this exists for. Only the sets at or
+        // above `MIN_NAMES` are gated at all; the small ones deliberately admit everything.
+        assert!(rejected > 0, "the gate rejected nothing across {} sets", sets.len());
+        assert!(
+            AttrGate::build(&[Box::from("class")]).is_none(),
+            "a one-name schema must not be gated: the scan it guards is cheaper than the test"
+        );
+        let _ = admitted_but_no_match;
+    }
+
+    /// A COLLISION must cost only the exact comparison, never an answer: two names sharing a bit are
+    /// normal (64 bits, and length folds in), so a gate built from one must admit the other and the
+    /// caller must then reject it by name. This is the property that makes one word enough.
+    #[test]
+    fn collisions_cost_a_comparison_and_not_an_answer() {
+        // distinct names, so a "collision" is never just the same name twice
+        let all: Vec<Box<str>> = (0u32..2000).map(|i| format!("a{i}").into()).collect();
+        // at least MIN_NAMES, or the gate declines to exist; the extras are distinct from the probes
+        let mut few: Vec<Box<str>> = vec![all[0].clone()];
+        few.extend((0..AttrGate::MIN_NAMES).map(|i| format!("zz-pad-{i}").into()));
+        let gate = AttrGate::build(&few).expect("a schema this size is gated");
+        let mut collided = 0u32;
+        for other in &all[1..] {
+            if gate.admits(other.as_bytes()) && !few.iter().any(|x| **x == **other) {
+                collided += 1;
+                // the gate admitted a name the schema does not reference; the exact comparison is what
+                // must then say no
+                assert!(!few.iter().any(|x| x.as_bytes().eq_ignore_ascii_case(other.as_bytes())));
+            }
+        }
+        assert!(collided > 0, "no collisions in 2000 names: the fixture is not testing the property");
+        // and the names it WAS built from are always admitted
+        for n in &few {
+            assert!(gate.admits(n.as_bytes()));
+        }
+    }
+}
+
+#[cfg(test)]
+mod open_elem_size {
+    use super::OpenElem;
+
+    /// Pushing an element memcpies this whole struct, so its size is a performance lever: 16 bytes added
+    /// here measured ~3.6% on a pure scan. A ceiling rather than an equality, since exact layout varies
+    /// with target; what it catches is a field added without weighing it against the per-element copy.
+    #[test]
+    fn stays_small_enough_to_push_cheaply() {
+        let bytes = std::mem::size_of::<OpenElem<'static>>();
+        assert!(
+            bytes <= 272,
+            "OpenElem grew to {bytes} bytes. That is a memcpy on every element push; measure it \
+             (tools/ab_bench.py --tables scan,deep) before raising this bound, and record the number."
+        );
     }
 }

--- a/src/matcher/sig.rs
+++ b/src/matcher/sig.rs
@@ -1,0 +1,212 @@
+//! One-sided 64-bit signatures: a Bloom filter that lets the matcher reject most (element, compound)
+//! pairs before it touches a single string. The shape is WebKit/Blink's `SelectorFilter`, narrowed to
+//! this engine's kernel.
+//!
+//! Every start tag builds a signature from the three things a compound can require *positively* — its
+//! tag name, its `id`, and each of its `class` tokens — mapping each to TWO bit positions and ORing
+//! them in. Each compiled compound gets a `req` built by the same hash over the same three sources. A
+//! compound whose `req` has a bit the element lacks cannot match, so `compound_matches` opens with one
+//! AND and one compare (see [`super::matching::compound_matches`]).
+//!
+//! # The two rules this file holds
+//!
+//! **One-sided.** A set bit is NECESSARY, never sufficient: collisions and the OR make false POSITIVES
+//! normal, and they cost only the exact comparisons that always ran. A false NEGATIVE is a silently
+//! dropped value, which the no-fallback contract cannot absorb. This module may only turn a `false` into
+//! a faster `false`.
+//!
+//! **The hash mirrors the comparison it guards.** `compound_matches` tests the tag with
+//! `eq_ignore_ascii_case` and the id/class tokens with `==`, so tag bytes are ASCII-folded on both sides
+//! and id/class bytes hashed verbatim on both. The class TOKENIZER is part of that: the element side
+//! hashes the tokens [`super::OpenElem::class_tokens`] yields and `has_class` compares the tokens it
+//! yields, from the one function. A wider split (Unicode whitespace) would hash `Foo` and `bar` out of
+//! `class="Foo\u{a0}bar"` while the predicate compares one token, so `.Foo\u{a0}bar` would be filtered
+//! out of a page it matches.
+//!
+//! Each source has its own hash basis, so a class `header` does not satisfy a `header` tag requirement.
+//! That is selectivity, not correctness.
+//!
+//! Signatures are built per START TAG, so each KIND of bit is included only for a schema that performs at
+//! least [`BITS_MIN`] tests of that kind — dropped from the element side and every `req` together, which
+//! is what keeps it sound.
+
+use crate::selector::Compound;
+
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+const FNV_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+// Per-source bases (FNV's basis, perturbed) keep the three kinds in separate hash spaces.
+const BASIS_TAG: u64 = FNV_BASIS;
+const BASIS_ID: u64 = FNV_BASIS ^ 0x9e37_79b9_7f4a_7c15;
+const BASIS_CLASS: u64 = FNV_BASIS ^ 0xc2b2_ae3d_27d4_eb4f;
+
+/// FNV-1a over `bytes`, ASCII-lowercasing as it goes when `fold`. Folding must match the guarded
+/// predicate exactly: `eq_ignore_ascii_case` folds only ASCII, and so does `to_ascii_lowercase` here —
+/// a non-ASCII byte hashes verbatim on both sides.
+///
+fn digest(basis: u64, bytes: &[u8], fold: bool) -> u64 {
+    let mut h = basis;
+    for &b in bytes {
+        let b = if fold { b.to_ascii_lowercase() } else { b };
+        h = (h ^ b as u64).wrapping_mul(FNV_PRIME);
+    }
+    h
+}
+
+/// The two bits a token claims. FNV-1a's low bits are not independent enough to slice twice, so the
+/// digest gets a finalizing mix first; the two 6-bit picks are then effectively independent, which is
+/// what makes a 64-bit filter with `k = 2` worth more than one with `k = 1`.
+fn bits(h: u64) -> u64 {
+    let mut m = h;
+    m ^= m >> 33;
+    m = m.wrapping_mul(0xff51_afd7_ed55_8ccd);
+    m ^= m >> 33;
+    (1u64 << (m & 63)) | (1u64 << ((m >> 6) & 63))
+}
+
+/// Bits for an element or compound TAG NAME — ASCII-folded (`eq_ignore_ascii_case`).
+pub(super) fn tag_bits(tag: &[u8]) -> u64 {
+    bits(digest(BASIS_TAG, tag, true))
+}
+
+/// Bits for an `id` value — verbatim (`compound_matches` compares ids with `==`).
+pub(super) fn id_bits(id: &[u8]) -> u64 {
+    bits(digest(BASIS_ID, id, false))
+}
+
+/// Bits for one `class` token — verbatim (`has_class` compares tokens with `==`).
+pub(super) fn class_bits(cls: &[u8]) -> u64 {
+    bits(digest(BASIS_CLASS, cls, false))
+}
+
+/// The signature bits compound `c` REQUIRES of an element, from its own positive tag/id/classes.
+///
+/// Everything else on the compound contributes nothing, and each omission is load-bearing:
+///   * `tag == None`/`"*"` — the universal selector requires no tag;
+///   * `negations` — a `:not(.x)` requirement is INVERTED; requiring `.x`'s bits would reject exactly
+///     the elements that match;
+///   * `is_groups` — `:is(a, b)` is an OR, so no single alternative is required (their own `req`s are
+///     set for when `compound_matches` recurses into them, where each IS the whole question);
+///   * `attrs` — `[href^="/"]` is a substring/prefix test, not the token equality the hash models
+///     (and `[class~=x]`/`[id=x]` go through the generic attribute path, whose value the signature
+///     does not summarize);
+///   * `positional`/`reverse`/`has`/`text_pred` — not element-identity at all.
+pub(super) fn compound_req(c: &Compound, o: Opts) -> u64 {
+    let mut req = 0u64;
+    if let (true, Some(t)) = (o.tag, c.tag.as_deref().filter(|t| *t != "*")) {
+        req |= tag_bits(t.as_bytes());
+    }
+    if let Some(id) = &c.id {
+        req |= id_bits(id.as_bytes());
+    }
+    if o.class {
+        for cl in &c.classes {
+            req |= class_bits(cl.as_bytes());
+        }
+    }
+    req
+}
+
+/// Which KINDS of bit a schema's signatures use. Applied to both sides — the element signature and
+/// every `req` — which is what keeps a disabled kind sound: if no `req` carries class bits, an element
+/// signature without class bits cannot fail to satisfy one. Soundness therefore does not depend on the
+/// cost estimate below being right, only on ONE decision driving both sides.
+#[derive(Clone, Copy)]
+pub(super) struct Opts {
+    pub tag: bool,
+    pub class: bool,
+}
+
+/// Hashing a kind costs per element, so a schema performing a single test of that kind cannot amortize
+/// it: unconditional class bits measured ~11% slower at one class-led field and ~4% faster at two.
+/// Below the threshold the bits leave BOTH sides, which is what keeps it sound.
+pub(super) const BITS_MIN: usize = 2;
+
+/// `id` has no threshold: it is one bounded `attrs` lookup and one hash of one value, and a schema that
+/// names an id is asking about a near-unique attribute — the filter's best case. The costly kinds are
+/// the ones counted below.
+///
+/// How many tag / class-membership tests this compound performs, counting the nested compounds that get
+/// their own `compound_matches` call. Feeds the [`BITS_MIN`] decision, which is a COST estimate:
+/// over- or under-counting can only buy or forgo the optimization, never change a match (see [`Opts`]).
+pub(super) fn tests(c: &Compound) -> (usize, usize) {
+    let mut tag = usize::from(c.tag.as_deref().is_some_and(|t| t != "*"));
+    let mut class = c.classes.len();
+    let nested = c
+        .negations
+        .iter()
+        .chain(c.is_groups.iter().flatten())
+        .chain(c.has.as_ref().map(|h| &*h.inner));
+    for n in nested {
+        let (t, cl) = tests(n);
+        tag += t;
+        class += cl;
+    }
+    (tag, class)
+}
+
+/// What a compiled schema's compounds actually require of an element, accumulated by the same walk
+/// that fills their `req`s ([`set_req`]).
+///
+/// Each flag OFF licenses the scan to skip building that part of the element signature, and the licence
+/// is sound because the flag and the `req`s come out of ONE walk under one [`Opts`]: a flag is off
+/// exactly when no `req` carries that kind of bit, so leaving those bits out of an element's signature
+/// cannot make a `req` unsatisfiable. What would break it is a second, separately-derived answer to
+/// "does this schema use classes?" — then the element side and the `req` side could disagree.
+///
+/// The flags are worth having because the work is per START TAG: class bits are `O(class tokens)` of
+/// hashing, tag bits one short hash, id bits an `attrs` lookup — all wasted on a schema whose compounds
+/// never ask.
+#[derive(Clone, Copy, Default)]
+pub(super) struct Wants {
+    mask: u64,       // OR of every compiled `req`
+    pub tag: bool,   // some compound names a concrete tag (and tag bits are enabled)
+    pub class: bool, // some compound carries a class token, so `has_class` will be asked
+    pub id: bool,    // some compound carries an id
+}
+
+impl Wants {
+    /// Does any compound require any bit? If not, every `req` is 0 and the whole filter is a no-op, so
+    /// the scan can skip signatures entirely.
+    pub(super) fn any(&self) -> bool {
+        self.mask != 0
+    }
+
+    /// Build every kind of bit — what the matching-kernel unit tests use, so their elements carry the
+    /// most selective signature any schema could ask for (the strictest test of one-sidedness).
+    #[cfg(test)]
+    pub(super) fn all() -> Wants {
+        Wants { mask: u64::MAX, tag: true, class: true, id: true }
+    }
+}
+
+/// [`set_req`] for the kernel unit tests, which build compounds one at a time and get their elements'
+/// signatures from [`Wants::all`] rather than from a compiled schema.
+#[cfg(test)]
+pub(super) fn set_req_for_test(c: &mut Compound) {
+    set_req(c, Opts { tag: true, class: true }, &mut Wants::default());
+}
+
+/// Fill in `c.req` and the `req` of every compound nested inside it (`:not(...)` args and
+/// `:is(...)`/`:where(...)` alternatives are matched by their own `compound_matches` call, so each is
+/// its own filterable question), accumulating what the scan must build into `w`.
+///
+/// Setting the reqs and accumulating `w` in ONE walk is deliberate: a compound this pass never reaches
+/// keeps `req == 0` (the filter is a no-op for it) *and* contributes nothing to `w`, so forgetting one
+/// can only cost speed. `w` must never be re-derived from anything but the reqs actually set here —
+/// that is the one way this filter turns into dropped values. (`o` is different in kind: a cost estimate
+/// the caller may compute however it likes, because it constrains BOTH sides equally.)
+pub(super) fn set_req(c: &mut Compound, o: Opts, w: &mut Wants) {
+    c.req = compound_req(c, o);
+    w.mask |= c.req;
+    w.tag |= o.tag && c.tag.as_deref().is_some_and(|t| t != "*");
+    w.class |= o.class && !c.classes.is_empty();
+    w.id |= c.id.is_some();
+    for neg in &mut c.negations {
+        set_req(neg, o, w);
+    }
+    for group in &mut c.is_groups {
+        for alt in group {
+            set_req(alt, o, w);
+        }
+    }
+}

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -95,6 +95,10 @@ pub struct Compound {
     // alternative compounds; the element must match ≥1 alternative in EVERY group (OR within a group,
     // AND across groups). Decided at open like `:not`, so no deferral. Empty = no `:is`/`:where`.
     pub is_groups: Vec<Vec<Compound>>,
+    /// DERIVED, not parsed: the signature bits an element must carry for this compound to have a
+    /// chance (see `matcher::sig`). The parser leaves it 0; the matcher's compile step fills it in.
+    /// 0 always means "filter nothing", so a compound that never reaches that step is merely slower.
+    pub req: u64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -5,7 +5,10 @@ lxml does *not* pin its vendored libxml2); `diff_lxml.py` is the gate; `conforma
 `foreign.py` generate test pages; `enc_check.py` (encoding parity), `sel_fuzz.py`/`diff_fuzz.py`
 (selector + malformed-HTML fuzz), `soak.py` (multi-seed soak), `support_snapshot.py`
 (regenerates/checks `docs/SUPPORT_SNAPSHOT.md`), `abi3_smoke.py` (stdlib-only floor check — the
-pinned toolchain can't be installed on py3.9), `bench_matrix.py`/`bench_corpus.py`/`bench_mem.py`/
+pinned toolchain can't be installed on py3.9), `ab_bench.py` (A/B two `bench` builds by
+**interleaving** them inside each cell, min-of-reps, reporting each cell's own jitter; aborts if the two
+builds disagree on the VALUE COUNT),
+`bench_matrix.py`/`bench_corpus.py`/`bench_mem.py`/
 `bench_webpoet.py` (benchmarks — the last one times `to_item()` at the PAGE-OBJECT level and verifies both
 items are identical before timing either; `--boundaries` measures the three shapes where the healthy-path
 curve does not hold, one of which Parsel wins outright, because a benchmark that only reports its good cases

--- a/tools/ab_bench.py
+++ b/tools/ab_bench.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""A/B two `bench` builds by INTERLEAVING them inside each cell.
+
+Sequential runs on a laptop drift 5-10%, which is larger than most real matcher wins, so each cell runs
+both binaries REP times alternating A,B,A,B,... and reports min-of-REP per side. Each cell also carries
+its own jitter -- the within-side spread -- because a delta smaller than that is not evidence: two
+identical binaries produce per-cell deltas up to +/-2.3% here. Calibrate by passing the same binary as
+--a and --b; every cell should then be marked `~`.
+
+Usage:
+    ab_bench.py --a <bench-binary-A> --b <bench-binary-B> [--reps N] [--iters N] [--tables ...] [--counts ...]
+
+Page generators and selector pools come from bench_matrix, so each workload is defined once.
+"""
+import argparse
+import functools
+import os
+import statistics
+import subprocess
+import sys
+import tempfile
+
+# Line-flush every row, so a long sweep read from a log is not lost to buffering.
+print = functools.partial(__builtins__.print, flush=True) if hasattr(__builtins__, "print") \
+    else functools.partial(__builtins__["print"], flush=True)
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import bench_matrix as bm  # noqa: E402  (page generators + selector pools, single-sourced)
+
+
+def run_bench(binary, html_path, sels, iters):
+    """One `bench` invocation -> µs/page. Selectors go on stdin (shell quoting can't corrupt them)."""
+    env = dict(os.environ, FROSTWORK_BENCH_ITERS=str(iters))
+    p = subprocess.run(
+        [binary, html_path], input="\n".join(sels), capture_output=True, text=True, env=env
+    )
+    if p.returncode != 0:
+        raise SystemExit(f"{binary} failed: {p.stderr.strip()}")
+    # stderr: bytes, nsel, us/page, pages/s, MB/s, vals/page
+    fields = p.stderr.strip().split("\t")
+    return float(fields[2]), int(fields[5])
+
+
+def cell(a, b, html_path, sels, iters, reps):
+    """Interleaved A,B,A,B,... -> (min_a, min_b, jitter, vals_a, vals_b). Interleaving puts drift on both
+    sides rather than on whichever build ran second; `jitter` is the worse within-side spread,
+    `(max - min) / min`, which is this cell's error bar."""
+    ta, tb, va, vb = [], [], None, None
+    for _ in range(reps):
+        t, va = run_bench(a, html_path, sels, iters)
+        ta.append(t)
+        t, vb = run_bench(b, html_path, sels, iters)
+        tb.append(t)
+    jitter = max((max(ta) - min(ta)) / min(ta), (max(tb) - min(tb)) / min(tb)) * 100.0
+    return min(ta), min(tb), jitter, va, vb
+
+
+def sweep(name, html, counts, pool, a, b, iters, reps, out):
+    with tempfile.NamedTemporaryFile("wb", suffix=".html", delete=False) as f:
+        f.write(html)
+        html_path = f.name
+    try:
+        kb = len(html) / 1024
+        print(f"\n### {name}  ({kb:.0f} KB)")
+        print(f"  {'sels':>4} | {'A µs':>10} {'B µs':>10} | {'delta':>8} {'jitter':>7} | {'vals':>7}")
+        print("  " + "-" * 58)
+        for c in counts:
+            sels = pool[:c]
+            ma, mb, jit, va, vb = cell(a, b, html_path, sels, iters, reps)
+            # A value-count mismatch means the two builds do not extract the same thing. That is a
+            # CORRECTNESS failure, not a slow cell, and it must not be reported as a percentage.
+            flag = "" if va == vb else f"  ** VALUE MISMATCH A={va} B={vb} **"
+            pct = (mb - ma) / ma * 100.0
+            # `~` marks a delta inside this cell's own jitter: not evidence, in either direction.
+            mark = " " if abs(pct) > jit else "~"
+            print(f"  {c:>4} | {ma:>10.1f} {mb:>10.1f} | {pct:>+7.1f}%{mark}{jit:>6.1f}% | {va:>7}{flag}")
+            out.append((name, c, ma, mb, pct, va == vb, jit))
+    finally:
+        os.unlink(html_path)
+
+
+# Workloads, chosen for what each can SEE: the tag-led pool barely exercises class work, so a
+# class-targeted change is invisible there. Both run over the same page so the contrast is readable.
+def tables(which):
+    med = 200_000
+    t = {}
+    t["class-led"] = ("class-led selectors, utility-CSS page", bm.class_heavy(med),
+                      bm.CLASS_COUNTS, bm.CLASS_POOL)
+    t["tag-led"] = ("tag-led selectors, utility-CSS page", bm.class_heavy(med),
+                    bm.CLASS_COUNTS, bm.POOL)
+    t["desc-led"] = ("descendant-led selectors, utility-CSS page", bm.class_heavy(med),
+                     bm.CLASS_COUNTS, bm.DESC_POOL)
+    t["desc-deep"] = ("descendant-led selectors, deep-nested page", bm.deep_nested(med),
+                      bm.CLASS_COUNTS, bm.DESC_POOL)
+    t["attr-led"] = ("attribute-predicate selectors, attribute-heavy page", bm.attr_heavy(med),
+                     bm.CLASS_COUNTS, bm.ATTR_POOL)
+    t["attr-page"] = ("class-led selectors, attribute-heavy page", bm.attr_heavy(med),
+                      bm.CLASS_COUNTS, bm.CLASS_POOL)
+    t["listing"] = ("product listing, tag-led", bm.product_listing(med), bm.CLASS_COUNTS, bm.POOL)
+    t["listing-class"] = ("product listing, class-led", bm.product_listing(med), bm.CLASS_COUNTS,
+                          bm.CLASS_POOL)
+    t["article"] = ("article (text-heavy)", bm.article(med), bm.CLASS_COUNTS, bm.POOL)
+    t["deep"] = ("deep-nested (ancestor-chain stress)", bm.deep_nested(med), bm.CLASS_COUNTS,
+                 bm.CLASS_POOL)
+    t["table"] = ("table (tag-dense)", bm.table(med), bm.CLASS_COUNTS, bm.POOL)
+    # The DEFERRED tiers: the only workloads that fill the per-element cold buffers, so the only ones
+    # where boxing that state could cost rather than pay.
+    t["tail"] = ("deferred-tail selectors (:has / :last-child)", bm.product_listing(med),
+                 [1, 2, 4, 8], bm.TAIL_POOL)
+    # A pure scan with no selectors must stay flat: per-element cost shows here with nothing to
+    # amortize it.
+    t["scan"] = ("pure scan (0 selectors -- must stay flat)", bm.class_heavy(med), [0], [])
+    return [t[k] for k in which]
+
+
+ALL = ["class-led", "tag-led", "desc-led", "desc-deep", "attr-led", "attr-page", "listing",
+       "listing-class", "article", "deep", "table", "tail", "scan"]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--a", required=True, help="baseline bench binary")
+    ap.add_argument("--b", required=True, help="candidate bench binary")
+    ap.add_argument("--reps", type=int, default=3, help="interleaved repetitions per cell (min taken)")
+    ap.add_argument("--iters", type=int, default=1200, help="pages per bench invocation")
+    ap.add_argument("--tables", default=",".join(ALL), help=f"comma list of {ALL}")
+    ap.add_argument("--counts", default="", help="override each table's selector counts, e.g. 8,16,32")
+    args = ap.parse_args()
+
+    which = [w.strip() for w in args.tables.split(",") if w.strip()]
+    bad = [w for w in which if w not in ALL]
+    if bad:
+        raise SystemExit(f"unknown table(s) {bad}; choose from {ALL}")
+
+    print("=" * 72)
+    print(f"A/B interleaved  reps={args.reps} iters={args.iters}  (min-of-reps per side)")
+    print(f"  A = {args.a}")
+    print(f"  B = {args.b}")
+    print("  delta < 0  =>  B (candidate) is FASTER")
+    print("=" * 72)
+
+    override = [int(c) for c in args.counts.split(",") if c.strip()] if args.counts else None
+    out = []
+    for name, html, counts, pool in tables(which):
+        sweep(name, html, override or counts, pool, args.a, args.b, args.iters, args.reps, out)
+
+    print("\n" + "=" * 72)
+    ok = all(same for *_, _, same, _ in out)
+    deltas = [pct for *_, pct, _, _ in out]
+    solid = [pct for *_, pct, _, jit in out if abs(pct) > jit]
+    print(f"cells={len(out)}  median delta={statistics.median(deltas):+.1f}%  "
+          f"best={min(deltas):+.1f}%  worst={max(deltas):+.1f}%")
+    print(f"  above own jitter: {len(solid)}/{len(out)} cells"
+          + (f"  (median {statistics.median(solid):+.1f}%)" if solid else "")
+          + "\n  cells marked ~ are inside their own jitter and are not evidence either way."
+          + "\n  To calibrate: run with --a and --b set to the SAME binary; every cell should read ~.")
+    if not ok:
+        print("VALUE MISMATCH in at least one cell -- the two builds do not agree on what they "
+              "extract. Timing is meaningless until that is fixed.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/bench_matrix.py
+++ b/tools/bench_matrix.py
@@ -45,6 +45,57 @@ TAIL_POOL = [
     "li:last-child a::attr(href)", "div:has(a) ::text",
 ]
 
+# CLASS-LED, high field count — where per-(element, selector) work dominates: every class-led compound
+# asks the element for its `class=` and looks for its own token. The tag-led POOL above barely exercises
+# that, so a change to class/id comparison is invisible there. Most fields deliberately DON'T match,
+# since a real schema's misses still cost a test per element.
+CLASS_POOL = [
+    ".price::text", ".title::text", ".desc::text", ".thumb::attr(src)", ".link::attr(href)",
+    ".card .price::text", ".card .title::text", ".product-card .desc::text",
+    ".badge::text", ".rating::text", ".sku::text", ".stock-label::text",
+    ".card .badge .value::text", ".breadcrumb a::attr(href)", ".pagination .next::attr(href)",
+    ".facet .label::text", ".swatch::attr(data-color)", ".promo .text-xl::text",
+    ".review .author::text", ".review .body::text", ".seller-name::text", ".shipping-note::text",
+    ".card .price-was::text", ".card .price-now::text", ".gallery img::attr(src)",
+    ".spec-table .name::text", ".spec-table .value::text", ".qty-input::attr(value)",
+    ".wishlist::attr(href)", ".compare::attr(href)", ".variant .title::text", ".tag-list a::text",
+]
+CLASS_COUNTS = [1, 2, 4, 8, 16, 32]
+
+# DESCENDANT-LED: every selector is 2-3 compounds, what a real page object mostly contains
+# (`.product-info .price::text`). CLASS_POOL is subject-led at its head, so it cannot see a change to the
+# ANCESTOR walk; this pool can. Most selectors deliberately do not match, which is the case that costs
+# the walk the most.
+DESC_POOL = [
+    ".card .price::text", ".card .title::text", ".product-card .desc::text",
+    ".grid .card .link::attr(href)", ".listing .thumb::attr(src)", ".panel .badge::text",
+    ".sidebar .facet .label::text", ".review .author::text", ".review .body::text",
+    ".spec-table .name::text", ".spec-table .value::text", ".gallery img::attr(src)",
+    ".breadcrumb a::attr(href)", ".pagination .next::attr(href)", ".promo .text-xl::text",
+    ".header .nav a::text", ".footer .links a::attr(href)", ".modal .close::attr(title)",
+    ".tabs .tab .label::text", ".accordion .item .head::text", ".rail .widget .title::text",
+    ".hero .cta::attr(href)", ".filters .chip::text", ".compare .row .cell::text",
+    ".variant .swatch::attr(data-color)", ".stock .label::text", ".shipping .note::text",
+    ".seller .name::text", ".rating .stars::attr(title)", ".qty .input::attr(value)",
+    ".wishlist .btn::attr(href)", ".related .card .title::text",
+]
+
+
+# ATTRIBUTE-PREDICATE-LED. The signature filter summarizes only tag/id/class, so a schema built on
+# `[data-x=y]` and `a[href^=/p]` gets nothing from it and pays a materialized-attribute lookup per
+# (element, predicate). Neither other pool contains an attribute predicate.
+ATTR_POOL = [
+    "[data-sku]::attr(data-sku)", "a[href^='/p/']::attr(href)", "[data-qty]::text",
+    "img[src$='.jpg']::attr(src)", "[data-variant]::text", "[data-track='view']::text",
+    "a[href*='promo']::attr(href)", "[data-price]::attr(data-price)", "[data-stock]::text",
+    "[data-color]::attr(data-color)", "[data-size]::text", "[data-brand]::attr(data-brand)",
+    "[data-rating]::text", "[data-reviews]::text", "[data-seller]::text", "[data-ship]::text",
+    "input[value]::attr(value)", "[data-cat]::text", "[data-sub]::text", "[data-id]::attr(data-id)",
+    "a[href$='.html']::attr(href)", "[data-img]::attr(data-img)", "[data-alt]::text",
+    "[data-tag]::text", "[data-promo]::text", "[data-badge]::text", "[data-new]::text",
+    "[data-sale]::text", "[data-eta]::text", "[data-store]::text", "[data-lang]::text",
+    "[data-cur]::text",
+]
 
 # ---- page generators (deterministic, ~size bytes) ----
 def article(size):
@@ -73,6 +124,41 @@ def table(size):
     while n < size:
         body.append(row); n += len(row)
     return f'<!DOCTYPE html><html><head><title>Data</title></head><body><table><tbody>{"".join(body)}</tbody></table></body></html>'.encode()
+
+
+def class_heavy(size):
+    """Utility-CSS markup: every element carries a handful of class tokens (the shape Tailwind-style
+    sites produce), so a class-led selector's token search is real work rather than a 1-token hit."""
+    card = ('<div class="card product-card flex flex-col rounded-lg shadow-sm p-4 mb-2">'
+            '<h3 class="title text-lg font-semibold leading-tight truncate">Widget Pro</h3>'
+            '<span class="price text-xl font-bold text-green-700">$19.99</span>'
+            '<a class="link btn btn-primary inline-block mt-2" href="/p/123">view</a>'
+            '<img class="thumb rounded object-cover w-full" src="/img/w.jpg" alt="w">'
+            '<p class="desc text-sm text-gray-600 leading-snug">A useful widget for many tasks.</p>'
+            '</div>')
+    body, n = [], 0
+    while n < size:
+        body.append(card); n += len(card)
+    return ('<!DOCTYPE html><html><head><title>Shop</title></head>'
+            f'<body><div class="grid grid-cols-3 gap-4 px-6">{"".join(body)}</div>'
+            '</body></html>').encode()
+
+
+def attr_heavy(size):
+    """Elements carrying several attributes each, most of which no selector references -- the shape a
+    component framework emits. Every one of them still meets `is_interesting` on the way in, so this is
+    where attribute MATERIALIZATION cost shows, separately from attribute matching."""
+    card = ('<div class="card" data-testid="card" data-index="7" role="listitem" aria-label="w">'
+            '<a class="link" href="/p/123" title="Widget" rel="nofollow" data-ga="click">Widget</a>'
+            '<img class="thumb" src="/img/w.jpg" alt="w" loading="lazy" width="120" height="90">'
+            '<span class="price" data-currency="USD" itemprop="price" content="19.99">$19.99</span>'
+            '<button class="add" type="button" data-action="add" aria-pressed="false">Add</button>'
+            '</div>')
+    body, n = [], 0
+    while n < size:
+        body.append(card); n += len(card)
+    return ('<!DOCTYPE html><html><head><title>Shop</title></head>'
+            f'<body><div class="grid">{"".join(body)}</div></body></html>').encode()
 
 
 def deep_nested(size):
@@ -145,15 +231,35 @@ def parsel_bench(html_bytes, sels):
     return (time.perf_counter() - t) / iters * 1e6
 
 
-def run_table(name, html_bytes, counts=COUNTS):
+# Rows accumulated for `--markdown`, so docs/BENCHMARKS.md is regenerated from a run rather than
+# transcribed by hand.
+MD_ROWS = []
+
+
+def emit_markdown():
+    """The `page type x selector count` table in docs/BENCHMARKS.md's exact shape."""
+    print("\n\n<!-- BEGIN generated: tools/bench_matrix.py --markdown -->")
+    print("| page (≈196 KB) | sels | engine µs | engine MB/s | Parsel µs | speedup |")
+    print("| --- | --- | --- | --- | --- | --- |")
+    last = None
+    for name, c, eus, embs, pus in MD_ROWS:
+        label = f"**{name.replace('_', '&#95;')}**" if name != last else ""
+        last = name
+        print(f"| {label} | {c} | {eus:.0f} | {embs:.0f} | {pus:.0f} | {pus / eus:.1f}× |")
+    print("<!-- END generated -->")
+
+
+def run_table(name, html_bytes, counts=COUNTS, pool=None):
+    pool = pool or POOL
     kb = len(html_bytes) / 1024
     print(f"\n### {name}  ({kb:.0f} KB)")
     print(f"  {'sels':>4} | {'engine µs':>10} {'MB/s':>7} {'vals':>6} | {'parsel µs':>10} | {'speedup':>7}")
     print("  " + "-" * 60)
     for c in counts:
-        sels = POOL[:c]
+        sels = pool[:c]
         eus, embs, vals = engine_bench(html_bytes, sels)
         pus = parsel_bench(html_bytes, sels)
+        MD_ROWS.append((name, c, eus, embs, pus))
         print(f"  {c:>4} | {eus:>10.1f} {embs:>7.0f} {vals:>6} | {pus:>10.1f} | {pus/eus:>6.1f}x")
 
 
@@ -161,6 +267,8 @@ def main():
     global SMOKE
     ap = argparse.ArgumentParser()
     ap.add_argument("--smoke", action="store_true", help="quick article/deep check at 8 and 32 selectors")
+    ap.add_argument("--markdown", action="store_true",
+                    help="also emit the docs/BENCHMARKS.md table, so it is regenerated not transcribed")
     args = ap.parse_args()
     SMOKE = args.smoke
     med = 200_000
@@ -186,6 +294,8 @@ def main():
     for name, html in pages:
         run_table(name, html, [8, 32] if args.smoke else COUNTS)
 
+    if args.markdown:
+        emit_markdown()
     if args.smoke:
         return
 


### PR DESCRIPTION
Three independent reductions in the matcher's per-element cost, prioritised for the schema shapes real
page objects have (class-led, 5–20 fields). No extracted value changes.

| change | measured |
| --- | --- |
| **One-sided signature filter** (`matcher/sig.rs`) — a 64-bit signature per element (tag, id, class tokens) ANDed against each compiled compound's requirement, rejecting most pairs before any string comparison | class-led −13% at 4 fields → −54% at 32 |
| **`OpenElem` 384 → 240 bytes** (`matcher::ColdState`) — the deferred tiers' per-element buffers behind one `Option<Box<_>>`; pushing an element memcpies the struct | −10% pure scan, −12% deep-nested |
| **Attribute gate** (`matcher::AttrGate`) — one bit test rejects an attribute no selector references, replacing a scan over every interesting name | attribute-led −4% → −9.5% |

Cumulatively against the merge base: class-led −17% (4 fields) to −55% (32), tag-led −4.5% to −21%,
attribute-led −4% to −9.5%, −7% to −14% across article / table / deep-nested / pure-scan. The
production-selector corpus median is 11 fields/page.

Confirmed one layer up: `FrostPage.to_item()` through the Python binding came down 8–17% at every field
count (1 field 0.32 → 0.30 ms, 8 → 0.52, 20 → 0.86).

## Correctness

Both filters are one-sided by construction — a set bit is necessary, never sufficient — so they can only
turn a `false` into a faster `false`. The shipped predicate and its test oracle are one function behind a
const generic, so they cannot drift, and the equality is swept exhaustively rather than spot-checked.

The class tokenizer is shared with the predicate it guards (`class_tokens`): HTML splits a class list on
ASCII whitespace only, so `class="a<U+3000>b"` is one class, and a wider split in the hash would drop a
value the predicate matches. A test fails if that sharing stops.

Both filters are gated on a measured floor (`sig::BITS_MIN`, `AttrGate::MIN_NAMES`) because a pre-filter
has to be cheaper than what it guards for the schemas that cannot use it.

`make ci` green: differential 0 DIVERGE / 0 CRASH, encoding parity, corpus parity, sequence sweep 0
differing shapes, selector fuzz, malformed-HTML fuzz NOVEL = 0, tree-rule audit, generated-table check,
support snapshot, pytest, mypy, web-poet differential + surface snapshot + mutation sweep, clippy. Plus a
new `OpenElem` size assertion.

## Benchmarks

`tools/ab_bench.py` is new: it interleaves two `bench` builds inside each cell and reports each cell's own
jitter, since two identical binaries differ by up to 2.3% per cell here. `bench_matrix.py` gains the pools
that can see changes the tag-led pool cannot, and `--markdown` so BENCHMARKS.md is regenerated rather than
transcribed.

**Some absolute figures in this diff go up.** The matrix had not been re-run since the initial commit,
across thirty commits of correctness work that costs per element, so the published numbers were ~1.7×
optimistic. All tables are regenerated; the two rows needing a corpus that is not in the repo are
labelled rather than left implying currency.

**Open question this PR does not address:** that ~1.7–1.9× absolute slowdown since the initial commit is a
lot to charge to correctness without checking. BENCHMARKS.md names the candidates in cost order.

## Rejected

- **Ancestor signature** (the OR of an element's and its ancestors' bits, to reject `div.foo a` before the
  ancestor walk): ~5% at 24–32 descendant-led fields, but +3% to +11% worse at 4–16 even when gated,
  because the residue is a wider `Segment` and a branch in the hot walk.
- **Member dedup**: the corpus schemas contain zero exact duplicate selectors.
- **Attribute-name interning**: after the gate, `attr()` scans 0.33–1.40 entries per element, the same at
  8 selectors as at 32.
