### PR TITLE
Let the engine own the str→UTF-8 step, and drop Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,8 +110,8 @@ jobs:
   bindings:
     name: bindings (py${{ matrix.python }} / ${{ matrix.os }})
     # The heavy differential runs once (above) on 3.12/linux. This matrix only builds the extension and
-    # runs the Python suite, cheaply covering the newest CPython and macOS. The abi3 FLOOR (3.9) is a
-    # separate job below — the pinned toolchain cannot be installed there at all.
+    # runs the Python suite, cheaply covering the newest CPython and macOS. The abi3 FLOOR is a separate
+    # job below, and since the floor moved to 3.10 it runs this same suite rather than a stand-in.
     strategy:
       fail-fast: false
       matrix:
@@ -133,13 +133,12 @@ jobs:
       - run: .venv/bin/python examples/basic.py  # keep the documented example runnable
 
   abi3-floor:
-    name: abi3 floor (py3.9 / ubuntu-latest)
-    # The wheel is abi3-py39, so 3.9 must keep working — but the pinned dev toolchain cannot be
-    # installed on it: `parsel`, `web-poet` and `pytest` all require >= 3.10. Running the pytest suite
-    # here is therefore impossible, not merely inconvenient (it failed at `pip install` on every run,
-    # which meant the floor was never actually tested). Instead: build the extension on a real 3.9 and
-    # exercise the dependency-free surface with tools/abi3_smoke.py (stdlib + frostwork only). Parity
-    # and the web-poet integration are covered by the jobs above, which own the pinned oracle.
+    name: abi3 floor (py3.10 / ubuntu-latest)
+    # The wheel is abi3-py310, so 3.10 must keep working. At the old 3.9 floor this job could not run the
+    # suite at all — `parsel`, `web-poet` and `pytest` each require >= 3.10, so it built the extension and
+    # ran tools/abi3_smoke.py (stdlib + frostwork only) as a stand-in. 3.10 is the first version where the
+    # pinned toolchain installs, so the floor now gets the SAME suite as every other interpreter, which is
+    # strictly more coverage than the smoke test it replaces.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -147,9 +146,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - run: python -m venv .venv
-      - run: .venv/bin/pip install maturin==1.14.1  # the one pin that supports 3.9
+      - run: .venv/bin/pip install -r requirements-test.txt
       - run: .venv/bin/maturin develop --release
-      - run: .venv/bin/python tools/abi3_smoke.py
+      - run: .venv/bin/python -m pytest tests/ -q
+      - run: .venv/bin/python tools/abi3_smoke.py   # the wheel must also work with NO dependencies present
       - run: .venv/bin/python examples/basic.py  # keep the documented example runnable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: release
 
-# Build abi3 wheels (one per platform, CPython >= 3.9) + an sdist, and publish to PyPI on a version
+# Build abi3 wheels (one per platform, CPython >= 3.10) + an sdist, and publish to PyPI on a version
 # tag. Publishing uses PyPI Trusted Publishing (OIDC) — no API token stored: configure this repo +
 # workflow as a trusted publisher for the `frostwork` project on PyPI, then push a tag (e.g. `v0.1.0`).
 on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,19 @@ First public preview.
 ### Python API and tooling
 
 - `frostwork.extract`, declarative `Page`/`Item`, grouped extraction and schema introspection.
+- `html` may be `str` as well as `bytes`, so code holding already-decoded text (a browser snapshot) does
+  not pre-encode a second copy of the document per response; the engine borrows CPython's UTF-8 view of
+  the string. A `str` is scanned as UTF-8, so an `encoding` label naming a different encoding is refused
+  rather than silently decoding those bytes wrongly.
 - `frostwork.check` and `frostwork-audit` for static schema validation; `frostwork-audit --scan` finds
   selector literals in existing Scrapy code without importing it.
 - `Item.empty_fields()` distinguishes supported selectors that matched nothing from unsupported coverage
   gaps already rejected by the audit.
-- An abi3 wheel targeting CPython 3.9 and newer. The optional web-poet integration requires Python 3.10 or
-  newer.
+- An abi3 wheel targeting CPython 3.10 and newer, which is also the floor for the optional web-poet
+  integration. The two used to differ: the core ran on 3.9 while web-poet required 3.10. They converged
+  when the wheel moved to `abi3-py310` so the engine could borrow a `str`'s UTF-8 view (below);
+  `PyUnicode_AsUTF8AndSize` is limited-API only from 3.10, and Python 3.9 reached end of life in October
+  2025.
 
 ### web-poet integration
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ html-escape = "0.2"
 encoding_rs = "0.8"
 # Only compiled when the `python` feature is on (i.e. maturin builds the extension). Plain
 # `cargo build`/`cargo test` and the differ/bench bins never pull it in.
-pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"], optional = true }
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py310"], optional = true }
 
 [features]
 python = ["dep:pyo3"]

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -304,4 +304,4 @@ native `Plan` **at class-creation time**, then each declared `field(selector)` b
 over `response.body`. So the idiomatic web-poet surface (`to_item()`, `Returns[Item]`, `@handle_urls`,
 mixing hand-written `@field` methods) is preserved while every selector field shares a single scan of a
 pre-compiled schema — a per-call `.css()` shim would re-scan per field and throw away the one-pass
-advantage, so we don't offer one. Wheels are abi3 (`abi3-py39`). Details: [PYTHON.md](PYTHON.md).
+advantage, so we don't offer one. Wheels are abi3 (`abi3-py310`). Details: [PYTHON.md](PYTHON.md).

--- a/docs/PYTHON.md
+++ b/docs/PYTHON.md
@@ -20,9 +20,12 @@ python -m venv .venv
 ```
 
 `--extras=webpoet` installs the supported web-poet release. Drop it if you only need
-`extract`/`Page`/`frostwork-audit`. Wheels are **abi3** (`abi3-py39`) and support CPython ≥ 3.9.
+`extract`/`Page`/`frostwork-audit`. Wheels are **abi3** (`abi3-py310`) and support CPython ≥ 3.10.
 
-**The web-poet extra needs Python ≥ 3.10**, which is narrower than the core. It supports
+**3.10 is the floor for everything** — core and extra alike. The core used to run on 3.9, with the
+web-poet extra the stricter half; the floors converged when the wheel moved to `abi3-py310` so the engine
+could borrow a `str`'s UTF-8 view instead of copying the document (`PyUnicode_AsUTF8AndSize` is
+limited-API only from 3.10). Python 3.9 reached end of life in October 2025. The extra supports
 `web-poet >= 0.24.1, < 0.25`, the release line exercised by the integration gates.
 
 ## 1. The primitive
@@ -213,11 +216,17 @@ Pick the base that matches the input the framework will inject:
 | base | input | notes |
 | --- | --- | --- |
 | `FrostPage` | `web_poet.HttpResponse` | scans `.body` bytes with the response's resolved `.encoding` |
-| `FrostBrowserPage` | `web_poet.BrowserResponse` | scans `.html`, encoded UTF-8 |
+| `FrostBrowserPage` | `web_poet.BrowserResponse` | scans `.html` as UTF-8, borrowed rather than re-encoded |
 | `FrostFields` | anything — override `frostwork_input()` | a `web_poet.ItemPage`: brings `to_item()` / `Returns[...]`, and is injectable |
 
 A `BrowserResponse` already contains decoded HTML, so Frostwork does not sniff a charset from it. Any
 remaining `<meta charset>` is ignored.
+
+The `str` is handed over **unencoded** — `frostwork_input()` may return `bytes` *or* `str`, and the engine
+borrows CPython's UTF-8 view of a `str` rather than allocating a second copy of the document. Return the
+original bytes where you have them, the `str` itself where you do not, and never
+`str.encode("utf-8")`. Because a `str` is scanned as UTF-8, the only `encoding` it accepts is `None` or a
+UTF-8 label; anything else is refused instead of decoding those bytes wrongly.
 
 For any other dependency, override the hook:
 
@@ -230,8 +239,17 @@ class MyPage(FrostFields):
     title = field("h1::text")
 ```
 
-Declaring a Frostwork `field()` on a class without a Frostwork page base raises at class definition. This
-prevents an unconverted marker from becoming a silently absent item field.
+Declaring a Frostwork `field()` on a class without a Frostwork page base raises `TypeError` at class
+definition. This prevents an unconverted marker from becoming a silently absent item field.
+
+On **Python 3.10 and 3.11 it arrives wrapped**: the check runs in `__set_name__`, and CPython before 3.12
+re-raises anything from `__set_name__` as `RuntimeError`
+([gh-77757](https://github.com/python/cpython/issues/77757) stopped that in 3.12). Frostwork's message is
+intact on `__cause__`, so the diagnosis is not lost, but code catching this needs both types:
+
+```python
+except (TypeError, RuntimeError) as exc:      # RuntimeError only on < 3.12; exc.__cause__ has the TypeError
+```
 
 `web_poet.SelectorExtractor` is not supported: its input is already a parsed tree, so serializing and
 re-scanning it would add work and could change the source. Query that `Selector` directly.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -187,12 +187,19 @@ When adding a gate or a coverage requirement, add a corresponding negative test.
 family, prove that the family reaches the intended behavior. Passing output is not evidence unless the same
 check can fail.
 
-## Python 3.9 wheel smoke test
+## The abi3 floor, and the dependency-free smoke test
 
-The core wheel is `abi3-py39`, while the pinned oracle and web-poet toolchain require a newer Python.
-`tools/abi3_smoke.py` therefore tests the dependency-free Python 3.9 surface separately: importing the
-extension, extraction, `Page`/`Item`, groups, audit and source scanning. Value parity remains the job of the
-oracle-backed jobs.
+The wheel is `abi3-py310`, so CPython 3.10 must keep working, and the floor job runs the same
+`pytest tests/` as every other interpreter. That is new. At the old 3.9 floor it could not: `parsel`,
+`web-poet` *and* `pytest` each require ≥ 3.10, so the job ran `tools/abi3_smoke.py` as a stand-in and the
+floor was never covered by the real suite. Raising the floor turned the weakest job in CI into a full one
+— and the first run there found a live bug (`RuntimeError` wrapping the `TypeError` a marker on a
+non-Frostwork base raises, on every Python before 3.12; see PYTHON.md).
+
+`tools/abi3_smoke.py` still runs there, now for the thing it is the only witness to: the core works with
+**no Python dependencies installed at all** — importing the extension, extraction, `Page`/`Item`, groups,
+audit and source scanning, standard library only. A venv holding parsel and web-poet cannot show that.
+Value parity remains the job of the oracle-backed jobs.
 
 ## Adding coverage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,13 @@ description = "Treeless, one-pass HTML extraction — CSS/XPath selectors matche
 readme = "README.md"
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [{ name = "Zyte" }]
 keywords = ["html", "scraping", "css-selectors", "xpath", "streaming", "web-poet", "scrapy"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Rust",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -41,8 +40,10 @@ dependencies = ["typing-extensions>=4.13"]
 # processor resolution this integration mirrors. To widen it: bump the pin, run `make gate-webpoet` and
 # `make gate-webpoet-mutate`, then raise the ceiling here.
 #
-# NOTE this extra is narrower than Frostwork's own `requires-python = ">=3.9"`: web-poet 0.24 requires
-# Python >= 3.10, so `pip install frostwork[webpoet]` needs 3.10+ even though the core does not.
+# NOTE the floor is now the same as this extra's: web-poet 0.24.1 needs Python >= 3.10, and since the
+# wheel moved to abi3-py310 (so the engine can BORROW a `str`'s UTF-8 view instead of copying the
+# document - `PyUnicode_AsUTF8AndSize` is limited-API only from 3.10) the core needs 3.10 too. The core
+# is what the 3.9 classifier is about; see docs/PYTHON.md.
 [project.optional-dependencies]
 webpoet = ["web-poet>=0.24.1,<0.25"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,10 +40,10 @@ dependencies = ["typing-extensions>=4.13"]
 # processor resolution this integration mirrors. To widen it: bump the pin, run `make gate-webpoet` and
 # `make gate-webpoet-mutate`, then raise the ceiling here.
 #
-# NOTE the floor is now the same as this extra's: web-poet 0.24.1 needs Python >= 3.10, and since the
-# wheel moved to abi3-py310 (so the engine can BORROW a `str`'s UTF-8 view instead of copying the
-# document - `PyUnicode_AsUTF8AndSize` is limited-API only from 3.10) the core needs 3.10 too. The core
-# is what the 3.9 classifier is about; see docs/PYTHON.md.
+# NOTE this extra no longer narrows the Python floor. It used to: web-poet needs >= 3.10 while the core
+# ran on 3.9, so `pip install frostwork[webpoet]` was the stricter half. The wheel is now abi3-py310
+# (the engine BORROWS a `str`'s UTF-8 view rather than copying the document, and
+# `PyUnicode_AsUTF8AndSize` is limited-API only from 3.10), so both halves want the same 3.10.
 [project.optional-dependencies]
 webpoet = ["web-poet>=0.24.1,<0.25"]
 

--- a/python/frostwork/_frostwork.pyi
+++ b/python/frostwork/_frostwork.pyi
@@ -5,15 +5,15 @@ one-pass primitives crossing the PyO3 boundary. `html` must be `bytes` (or a `by
 as web-poet's `HttpResponseBody`); the pure-Python wrappers accept other bytes-likes and `str`.
 """
 
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 def extract(
-    html: bytes, queries: List[str], encoding: Optional[str] = ...
+    html: Union[bytes, str], queries: List[str], encoding: Optional[str] = ...
 ) -> List[List[str]]:
     """One streaming pass: one value-column per query, in query order."""
 
 def extract_grouped(
-    html: bytes,
+    html: Union[bytes, str],
     flat_queries: List[str],
     groups: List[Tuple[str, List[Tuple[str, str]]]],
     encoding: Optional[str] = ...,
@@ -54,7 +54,7 @@ class Plan:
         flat_queries: List[str],
         groups: List[Tuple[str, List[Tuple[str, str]]]],
     ) -> None: ...
-    def extract(self, html: bytes, encoding: Optional[str] = ...) -> List[List[str]]: ...
+    def extract(self, html: Union[bytes, str], encoding: Optional[str] = ...) -> List[List[str]]: ...
     def extract_grouped(
-        self, html: bytes, encoding: Optional[str] = ...
+        self, html: Union[bytes, str], encoding: Optional[str] = ...
     ) -> Tuple[List[List[str]], List[List[List[List[str]]]]]: ...

--- a/python/frostwork/page.py
+++ b/python/frostwork/page.py
@@ -45,10 +45,13 @@ _Card = Tuple[str, Optional[str]]
 Bytesish = Union[bytes, bytearray, memoryview, str]
 
 
-def _as_bytes(html: Bytesish) -> bytes:
-    """Frostwork tokenizes raw bytes. `str` is encoded as UTF-8 (already-decoded text)."""
-    if isinstance(html, str):
-        return html.encode("utf-8")
+def _as_scan_input(html: Bytesish) -> Union[bytes, str]:
+    """What the engine scans. `bytes` and `str` both cross the FFI boundary as-is — the native layer
+    borrows a `str`'s UTF-8 view instead of allocating a second copy of the document (see the `Html`
+    enum in `src/python.rs`), so a caller holding already-decoded text should NOT pre-encode it. Only
+    the remaining bytes-likes need materializing."""
+    if isinstance(html, (bytes, str)):
+        return html
     return bytes(html)
 
 
@@ -168,7 +171,7 @@ def extract(
     encoding = _check_encoding(html, encoding)
     if strict:
         _validate_flat(tuple(query_list))
-    return _extract(_as_bytes(html), query_list, encoding)
+    return _extract(_as_scan_input(html), query_list, encoding)
 
 
 def extract_grouped(
@@ -192,7 +195,7 @@ def extract_grouped(
     if strict:
         group_key = tuple((container, tuple(subfields)) for container, subfields in group_list)
         _validate_grouped(tuple(query_list), group_key)
-    return _extract_grouped(_as_bytes(html), query_list, group_list, encoding)
+    return _extract_grouped(_as_scan_input(html), query_list, group_list, encoding)
 
 
 # --------------------------------------------------------------------------- schema audit / validation
@@ -603,7 +606,7 @@ class Page:
             self.check().raise_for_status()
             self._validated = True
         encoding = _check_encoding(html, encoding)
-        body = _as_bytes(html)
+        body = _as_scan_input(html)
         plan = self._get_plan()  # compiled once, reused across pages
         if not self._groups:
             cols = plan.extract(body, encoding)

--- a/python/frostwork/webpoet.py
+++ b/python/frostwork/webpoet.py
@@ -45,6 +45,7 @@ from typing import (
     Optional,
     Tuple,
     TypeVar,
+    Union,
     overload,
 )
 
@@ -871,15 +872,19 @@ class FrostFields(ItemPage):
             },
         }
 
-    def frostwork_input(self) -> Tuple[bytes, Optional[str]]:
-        """The ``(html_bytes, encoding)`` this page object scans. Override to source a page object from
+    def frostwork_input(self) -> Tuple[Union[bytes, str], Optional[str]]:
+        """The ``(html, encoding)`` this page object scans — ``bytes`` off the wire, or a ``str`` of
+        already-decoded text (a browser snapshot). Override to source a page object from
         something other than the two provided bases — that is the whole extension point, and it is public
         because web-poet's input universe is larger than the shapes shipped here (``Extractor`` subclasses
         can be given any dependency at all).
 
         ``encoding`` may be ``None``, in which case the engine sniffs (BOM, then a ``<meta>`` prescan)
         exactly as Parsel would. Return the ORIGINAL bytes where you have them: decoding to ``str`` and
-        re-encoding can only lose information the sniffer would otherwise use."""
+        re-encoding can only lose information the sniffer would otherwise use. Where only decoded text
+        exists, return the ``str`` itself — never ``str.encode("utf-8")``, which allocates a whole
+        second copy of the document; the engine borrows CPython's UTF-8 view instead. A ``str`` is
+        scanned as UTF-8, so the only ``encoding`` it accepts is ``None`` or a UTF-8 label."""
         raise NotImplementedError(
             f"{type(self).__name__} does not define frostwork_input(). Inherit FrostPage (HttpResponse) "
             "or FrostBrowserPage (BrowserResponse), or override frostwork_input() to return "
@@ -923,9 +928,14 @@ class FrostBrowserPage(FrostFields, BrowserPage):
     bytes off the wire. Identical to :class:`FrostPage` in every other respect.
 
     A ``BrowserResponse`` carries ``.html`` (a ``str``) and no bytes, so there is nothing to sniff: the
-    text is encoded UTF-8 and scanned with the encoding stated rather than guessed. That is not a
-    shortcut — the browser has already resolved the page's encoding, and re-deriving it from a
-    re-encoding of the decoded text could only disagree with the browser that produced it."""
+    text is scanned as UTF-8 with the encoding stated rather than guessed. That is not a shortcut — the
+    browser has already resolved the page's encoding, and re-deriving it from a re-encoding of the
+    decoded text could only disagree with the browser that produced it.
 
-    def frostwork_input(self) -> Tuple[bytes, Optional[str]]:
-        return str(self.response.html).encode("utf-8"), "utf-8"
+    The ``str`` is handed over **unencoded**: the engine borrows CPython's UTF-8 view of it rather than
+    allocating a second copy of the document per response. For an all-ASCII snapshot that view IS the
+    string's own buffer, so the conversion costs nothing at all."""
+
+    def frostwork_input(self) -> Tuple[Union[bytes, str], Optional[str]]:
+        # `.html` is a `str` subclass (BrowserHtml); pass it through, do NOT `.encode()` it.
+        return self.response.html, "utf-8"

--- a/src/python.rs
+++ b/src/python.rs
@@ -41,6 +41,115 @@ fn budget_error((members, sib): (usize, usize)) -> PyResult<()> {
     Ok(())
 }
 
+/// The canonical WHATWG encoding name for `label` (e.g. `"UTF-8"`), or `None` if this crate does not
+/// recognize it. Shared by the `resolve_label` binding and [`Html::encoding`], so the two cannot drift.
+fn canonical_label(label: &str) -> Option<&'static str> {
+    encoding_rs::Encoding::for_label(label.as_bytes()).map(|e| e.name())
+}
+
+/// The WHATWG encoding a label names *via Python's codec set* — `codecs.lookup(label).name` fed back
+/// through [`canonical_label`]. `None` when Python does not know the label, or knows it but WHATWG does
+/// not name the result.
+///
+/// This is deliberately the same two-step `frostwork.page._check_encoding` performs, because the two
+/// must agree about every label. `latin-1` is the case that forces it: WHATWG defines `iso-8859-1` and
+/// not `latin-1`, so WHATWG alone cannot see that `latin-1` means windows-1252 and would let a
+/// mojibake-producing label through. `utf-8-sig` is the case that forces the second `None`: Python
+/// resolves it and WHATWG does not name it, so the label is ignored and the text scanned as UTF-8 —
+/// which is what it is.
+fn whatwg_via_python_codecs(py: Python<'_>, label: &str) -> Option<&'static str> {
+    let codecs = py.import("codecs").ok()?;
+    let info = codecs.call_method1("lookup", (label,)).ok()?;
+    let name: String = info.getattr("name").ok()?.extract().ok()?;
+    canonical_label(&name)
+}
+
+/// The document to scan, as Python hands it over: raw `bytes` off the wire, or an already-decoded
+/// `str` (a browser snapshot — `web_poet.BrowserResponse.html`, `AnyResponse.text`).
+///
+/// `str` is here so callers do not have to write `.encode("utf-8")`, which allocates a whole second
+/// copy of the document per response. On CPython >= 3.10 `&str` extraction is
+/// `PyUnicode_AsUTF8AndSize`: for a compact-ASCII `str` that is a pointer INTO the string object, so
+/// the copy disappears entirely; for a non-ASCII `str` CPython transcodes once and caches the result
+/// ON the string, so a second page object over the same response is free. Either way Frostwork, not
+/// the caller, owns the conversion.
+///
+/// It is NOT free in general: a non-ASCII Python `str` is stored as UCS-2/UCS-4, so its first
+/// UTF-8 view has to be built. That cost is imposed by the representation, not by this crate — a
+/// caller holding the original bytes should pass those.
+enum Html<'a> {
+    // `bytes` first: the documented, preferred input, and the only one on the crawl hot path.
+    Bytes(&'a [u8]),
+    Str(&'a str),
+}
+
+// Hand-written rather than `#[derive(FromPyObject)]`: the derive cannot tie a borrowed variant's
+// lifetime to the input object's, so it rejects an enum holding `&'a [u8]` / `&'a str`. Both arms
+// delegate to PyO3's own borrowing extractors, so neither copies.
+impl<'a, 'py> FromPyObject<'a, 'py> for Html<'a> {
+    type Error = PyErr;
+
+    fn extract(ob: pyo3::Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(bytes) = <&'a [u8] as FromPyObject>::extract(ob) {
+            return Ok(Html::Bytes(bytes));
+        }
+        if let Ok(text) = <&'a str as FromPyObject>::extract(ob) {
+            return Ok(Html::Str(text));
+        }
+        Err(pyo3::exceptions::PyTypeError::new_err(format!(
+            "frostwork: html must be bytes (preferred - the engine tokenizes raw bytes) or str \
+             (already-decoded text, e.g. a browser snapshot), got {}. For a bytearray/memoryview use \
+             the frostwork.extract wrapper, which converts them.",
+            ob.get_type().name().map(|n| n.to_string()).unwrap_or_else(|_| "?".into())
+        )))
+    }
+}
+
+impl Html<'_> {
+    fn as_bytes(&self) -> &[u8] {
+        match self {
+            Html::Bytes(b) => b,
+            Html::Str(s) => s.as_bytes(),
+        }
+    }
+
+    /// The encoding to scan with, given the caller's label.
+    ///
+    /// For `bytes` the label passes through: the engine sniffs when it is `None`, exactly as before.
+    ///
+    /// For `str` the bytes handed on are UTF-8 by construction, so there is nothing to sniff and
+    /// nothing to guess — the answer is UTF-8, and a `<meta charset>` surviving in a browser snapshot
+    /// is correctly ignored.
+    ///
+    /// Only a label that resolves to a DIFFERENT encoding is refused, because that one would decode
+    /// UTF-8 bytes as, say, cp1252 and quietly produce mojibake — the plausible-wrong-value the
+    /// no-fallback contract exists to rule out. A label nothing can resolve is *not* refused: the
+    /// engine's rule for one is WHATWG's "failure, continue" (ignore it and sniff), and for
+    /// already-decoded text ignoring it lands on UTF-8, which is right.
+    ///
+    /// Resolution has to consult BOTH label universes, or the same argument means different things
+    /// through the two entry points. WHATWG defines `iso-8859-1` but not `latin-1`, and Python defines
+    /// `utf_8`/`utf-8-sig`/`U8` which WHATWG does not — so `frostwork.extract` (which normalizes through
+    /// `codecs`) and a direct `Plan` call (which does not go through it, and is the path
+    /// `frostwork.webpoet` uses) would disagree on both sets. `codecs` is consulted only when this
+    /// crate cannot resolve the label itself, so the common path stays inside Rust.
+    fn encoding<'e>(&self, py: Python<'_>, label: Option<&'e str>) -> PyResult<Option<&'e str>> {
+        let Html::Str(_) = self else {
+            return Ok(label); // bytes: pass the label through, `None` still sniffs
+        };
+        let Some(l) = label else { return Ok(Some("utf-8")) };
+        let resolved = canonical_label(l).or_else(|| whatwg_via_python_codecs(py, l));
+        match resolved {
+            Some(name) if name != "UTF-8" => Err(PyValueError::new_err(format!(
+                "frostwork: html is already-decoded str (tokenized as UTF-8), but encoding={l:?} \
+                 resolves to {name}, which would decode those bytes wrongly — pass the original bytes \
+                 with the label, or drop the label."
+            ))),
+            _ => Ok(Some("utf-8")),
+        }
+    }
+}
+
 /// A schema compiled ONCE and reused across pages — the native object behind `frostwork.Page` /
 /// `FrostPage`, which build a `Plan` a single time and call it per response instead of re-sending
 /// string selectors (and re-parsing them) every page. The budget is validated at construction, so an
@@ -63,11 +172,18 @@ impl Plan {
     }
 
     /// One streaming pass over `html`, returning one value-column per flat query (query order).
-    /// The GIL is released for the duration of the scan (`html` is an immutable `bytes` buffer and
+    /// The GIL is released for the duration of the scan (`html` is an immutable buffer and
     /// the compiled plan is read-only), so concurrent extracts on a thread pool run in parallel.
     #[pyo3(signature = (html, encoding=None))]
-    fn extract(&self, py: Python<'_>, html: &[u8], encoding: Option<&str>) -> Vec<Vec<String>> {
-        py.detach(|| self.inner.extract(html, encoding).0)
+    fn extract(
+        &self,
+        py: Python<'_>,
+        html: Html<'_>,
+        encoding: Option<&str>,
+    ) -> PyResult<Vec<Vec<String>>> {
+        let encoding = html.encoding(py, encoding)?;
+        let bytes = html.as_bytes();
+        Ok(py.detach(|| self.inner.extract(bytes, encoding).0))
     }
 
     /// One streaming pass returning `(flat_columns, grouped)` — see the `extract_grouped` free function.
@@ -77,16 +193,19 @@ impl Plan {
     fn extract_grouped(
         &self,
         py: Python<'_>,
-        html: &[u8],
+        html: Html<'_>,
         encoding: Option<&str>,
-    ) -> (Vec<Vec<String>>, Vec<Vec<Vec<Vec<String>>>>) {
-        py.detach(|| self.inner.extract(html, encoding))
+    ) -> PyResult<(Vec<Vec<String>>, Vec<Vec<Vec<Vec<String>>>>)> {
+        let encoding = html.encoding(py, encoding)?;
+        let bytes = html.as_bytes();
+        Ok(py.detach(|| self.inner.extract(bytes, encoding)))
     }
 }
 
 /// One streaming pass over `html`, returning one value-column per query (in query order) — the exact
-/// output of [`crate::extract`]. `html` must be `bytes` (or a `bytes` subclass such as web-poet's
-/// `HttpResponseBody`); the pure-Python `frostwork.extract` wrapper converts other bytes-likes.
+/// output of [`crate::extract`]. `html` is `bytes` (or a `bytes` subclass such as web-poet's
+/// `HttpResponseBody`) or an already-decoded `str` — see [`Html`]; the pure-Python `frostwork.extract`
+/// wrapper converts the remaining bytes-likes.
 /// `encoding` is an optional charset label as Scrapy passes from `Content-Type`; `None` sniffs
 /// (BOM → `<meta>` → UTF-8). Unsupported queries yield an empty column — there is no fallback.
 /// Raises `ValueError` if the schema exceeds the member/sibling-bit budget (a caller bug).
@@ -94,12 +213,14 @@ impl Plan {
 #[pyo3(signature = (html, queries, encoding=None))]
 fn extract(
     py: Python<'_>,
-    html: &[u8],
+    html: Html<'_>,
     queries: Vec<String>,
     encoding: Option<&str>,
 ) -> PyResult<Vec<Vec<String>>> {
     check_budget(&queries, &[])?;
-    Ok(py.detach(|| crate::extract(html, &queries, encoding)))
+    let encoding = html.encoding(py, encoding)?;
+    let bytes = html.as_bytes();
+    Ok(py.detach(|| crate::extract(bytes, &queries, encoding)))
 }
 
 /// One streaming pass returning `(flat_columns, grouped)`. `groups` is a list of
@@ -112,14 +233,16 @@ fn extract(
 #[allow(clippy::type_complexity)]
 fn extract_grouped(
     py: Python<'_>,
-    html: &[u8],
+    html: Html<'_>,
     flat_queries: Vec<String>,
     groups: Vec<(String, Vec<(String, String)>)>,
     encoding: Option<&str>,
 ) -> PyResult<(Vec<Vec<String>>, Vec<Vec<Vec<Vec<String>>>>)> {
     let gq = group_queries(groups);
     check_budget(&flat_queries, &gq)?;
-    Ok(py.detach(|| crate::extract_grouped(html, &flat_queries, &gq, encoding)))
+    let encoding = html.encoding(py, encoding)?;
+    let bytes = html.as_bytes();
+    Ok(py.detach(|| crate::extract_grouped(bytes, &flat_queries, &gq, encoding)))
 }
 
 /// Resolve `label` against the engine's charset-label set (WHATWG labels), returning the canonical
@@ -129,7 +252,7 @@ fn extract_grouped(
 /// philosophy forbids surfacing silently).
 #[pyfunction]
 fn resolve_label(label: &str) -> Option<&'static str> {
-    encoding_rs::Encoding::for_label(label.as_bytes()).map(|e| e.name())
+    canonical_label(label)
 }
 
 /// `Support` as a Python-facing `(supported: bool, reason: Optional[str])` tuple.

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -7,12 +7,40 @@ parsel cross-check that values survive the FFI boundary unchanged.
 """
 
 import asyncio
+import contextlib
+import re
+import sys
 
 import pytest
 
 import frostwork
 from frostwork import Page
 from frostwork._frostwork import Plan as _Plan
+
+
+@contextlib.contextmanager
+def raises_at_class_definition(match):
+    """Assert a `field()`/`Many()` misdeclaration is refused when the class is created, and that the
+    diagnosis reaches the user — on every supported interpreter.
+
+    The library raises `TypeError` from `_FrostField.__set_name__`, but CPython **wraps whatever
+    `__set_name__` raises in `RuntimeError` before 3.12** (gh-77757 stopped doing so in 3.12). So on the
+    abi3 floor (3.10) and on 3.11 a user catches `RuntimeError` whose `__cause__` carries Frostwork's
+    message, and from 3.12 they catch the `TypeError` directly. Asserting only `TypeError` made this
+    suite pass on the dev interpreter and fail on the floor — which is exactly what nobody saw while the
+    floor job could not run pytest at all."""
+    with pytest.raises((TypeError, RuntimeError)) as excinfo:
+        yield
+    err = excinfo.value
+    chain = [err]
+    while chain[-1].__cause__ is not None:
+        chain.append(chain[-1].__cause__)
+    assert any(re.search(match, str(e)) for e in chain), (
+        f"none of {[type(e).__name__ for e in chain]} carried {match!r}: "
+        f"{[str(e)[:80] for e in chain]}"
+    )
+    if sys.version_info >= (3, 12):
+        assert isinstance(err, TypeError), f"3.12+ should surface TypeError unwrapped, got {err!r}"
 
 PRODUCT = (
     b"<div class=product><h1>Widget</h1><span class=price>$9</span>"
@@ -531,7 +559,7 @@ def test_a_real_zyte_product_page_composes_and_every_processor_fires():
         images = field("img.hero::attr(src)", all=True)   # scalar terminal: URL strings, not nodes
 
     # the declaration that does NOT work, pinned so the docs cannot drift back to it
-    with pytest.raises(TypeError, match="does not inherit a Frostwork page base"):
+    with raises_at_class_definition("does not inherit a Frostwork page base"):
         type("Wrong", (ProductPage,), {"name": field("h1::text")})
 
     item = asyncio.run(MyProductPage(response=_resp(body=html)).to_item())
@@ -1226,9 +1254,9 @@ def test_a_marker_on_a_non_frost_class_fails_at_class_definition():
     from frostwork.webpoet import Many, field
 
     for base in (WebPage, BrowserPage):
-        with pytest.raises(TypeError, match="does not inherit a Frostwork page base"):
+        with raises_at_class_definition("does not inherit a Frostwork page base"):
             type("Bad", (base,), {"name": field("h1::text")})
-        with pytest.raises(TypeError, match="does not inherit a Frostwork page base"):
+        with raises_at_class_definition("does not inherit a Frostwork page base"):
             type("BadGroup", (base,), {"rows": Many(".card", title=field("h3 a::text"))})
 
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -12,6 +12,7 @@ import pytest
 
 import frostwork
 from frostwork import Page
+from frostwork._frostwork import Plan as _Plan
 
 PRODUCT = (
     b"<div class=product><h1>Widget</h1><span class=price>$9</span>"
@@ -136,6 +137,29 @@ def test_extract_str_with_non_utf8_label_raises():
         frostwork.extract("<p>café</p>", ["p::text"], "windows-1252")
     # a UTF-8 label on str is consistent and allowed
     assert frostwork.extract("<p>café</p>", ["p::text"], "utf-8") == [["café"]]
+
+
+@pytest.mark.parametrize("label", [None, "utf-8", "utf8", "UTF-8", "utf_8", "utf-8-sig", "U8"])
+def test_a_str_accepts_every_utf8_label_spelling_through_both_entry_points(label):
+    """`extract` normalizes Python codec spellings through `codecs`, and the native layer resolves
+    WHATWG labels — two different labelling universes over the same argument. `utf_8`, `utf-8-sig` and
+    `U8` are UTF-8 to Python and unknown to WHATWG, so a native check that demanded a WHATWG UTF-8 name
+    made the same label mean different things through `extract` (accepted) and through `Plan` (refused),
+    which is the path `frostwork.webpoet` uses. Both must answer the same way."""
+    html = "<p>café</p>"
+    assert frostwork.extract(html, ["p::text"], label) == [["café"]]
+    assert _Plan(["p::text"], []).extract(html, label) == [["café"]]
+
+
+@pytest.mark.parametrize("label", ["windows-1252", "latin-1", "iso-8859-1", "shift_jis", "gb18030"])
+def test_a_str_refuses_a_label_that_resolves_to_another_encoding(label):
+    """The mojibake this exists to prevent: UTF-8 bytes decoded as something else. Refused on BOTH
+    entry points, since a direct `Plan` call bypasses the pure-Python check entirely."""
+    html = "<p>café</p>"
+    with pytest.raises(ValueError):
+        frostwork.extract(html, ["p::text"], label)
+    with pytest.raises(ValueError):
+        _Plan(["p::text"], []).extract(html, label)
 
 
 def test_extract_grouped_normalizes_list_shaped_groups():

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -24,7 +24,7 @@ import pytest
 pytest.importorskip("mypy", reason="mypy is pinned in requirements-test.txt")
 pytest.importorskip("web_poet")
 
-# `typing.assert_type` landed in 3.11; the wheel's abi3 floor (3.9) is a separate concern from the dev
+# `typing.assert_type` landed in 3.11; the wheel's abi3 floor (3.10) is a separate concern from the dev
 # toolchain, which requires >= 3.10 anyway (see the CI workflow's note).
 pytestmark = pytest.mark.skipif(
     sys.version_info < (3, 11), reason="typing.assert_type requires Python 3.11+"

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -4,8 +4,8 @@ Python harness (needs `parsel`). `oracle.py` guards the oracle toolchain (libxml
 lxml does *not* pin its vendored libxml2); `diff_lxml.py` is the gate; `conformant.py`/`families.py`/
 `foreign.py` generate test pages; `enc_check.py` (encoding parity), `sel_fuzz.py`/`diff_fuzz.py`
 (selector + malformed-HTML fuzz), `soak.py` (multi-seed soak), `support_snapshot.py`
-(regenerates/checks `docs/SUPPORT_SNAPSHOT.md`), `abi3_smoke.py` (stdlib-only floor check — the
-pinned toolchain can't be installed on py3.9), `ab_bench.py` (A/B two `bench` builds by
+(regenerates/checks `docs/SUPPORT_SNAPSHOT.md`), `abi3_smoke.py` (stdlib-only check that the
+extension works with no dependencies present), `ab_bench.py` (A/B two `bench` builds by
 **interleaving** them inside each cell, min-of-reps, reporting each cell's own jitter; aborts if the two
 builds disagree on the VALUE COUNT),
 `bench_matrix.py`/`bench_corpus.py`/`bench_mem.py`/

--- a/tools/abi3_smoke.py
+++ b/tools/abi3_smoke.py
@@ -1,13 +1,13 @@
-"""abi3-floor smoke test: does the built extension actually work on the OLDEST supported interpreter?
+"""abi3-floor smoke test: does the built extension work with NO Python dependencies installed?
 
-Frostwork ships an **abi3-py39** wheel, but the pinned dev toolchain cannot be installed on Python 3.9
-at all — `parsel`, `web-poet` AND `pytest` each require >= 3.10 (checked 2026-07-29). So the floor
-cannot be verified by running `tests/test_python.py`; before this script CI tried to and the job failed
-on `pip install` every time, which meant the abi3 floor was never actually exercised.
+Frostwork's core (`extract`, `Page`/`Item`, `check`, the `frostwork-audit` CLI) is documented to need
+nothing but the compiled extension — no parsel, no web-poet, no pytest. `tests/test_python.py` cannot
+show that, because installing it installs those very packages.
 
 This script therefore uses NOTHING but the standard library and `frostwork` itself, and asserts the
 dependency-free surface: the primitive, strict/permissive modes, `Page`/`Item` with groups, the schema
-audit, and the source scan. Run it on any interpreter (>= 3.9) after building the extension:
+audit, and the source scan. Run it on any supported interpreter (>= 3.10, the abi3 floor) after building
+the extension:
 
     .venv/bin/python tools/abi3_smoke.py
 


### PR DESCRIPTION
`FrostBrowserPage.frostwork_input` returned `response.html.encode("utf-8")`, and any caller holding only
decoded text had to do the same — a second copy of the document per response, for a conversion the engine
is better placed to make. `bytes` and `str` now both cross the FFI boundary as-is.

## What changed

- **`html` may be `str`.** `extract`, `extract_grouped` and `Plan.*` accept already-decoded text. The new
  `Html` enum in `src/python.rs` borrows CPython's UTF-8 view via `PyUnicode_AsUTF8AndSize`.
- **A `str` with a non-UTF-8 `encoding` label is refused** — it would decode UTF-8 bytes as cp1252 and
  quietly produce mojibake. Now enforced on a direct `Plan` call too, which is the path
  `frostwork.webpoet` uses.
- **Python floor 3.9 → 3.10, wheels `abi3-py39` → `abi3-py310`.** Required: `&str` extraction does not
  exist under the 3.9 limited API, and `PyUnicode_AsUTF8AndSize` is not declared in `pyo3-ffi` there.

## Read the measurement before the diff

This is **not** the win it looks like. `str.encode()` is ~12% of a browser-sourced scan on a 530 KB page,
but that 12% is a UCS-2→UTF-8 transcode CPython performs for anyone asking for UTF-8 bytes — PyO3 pays it
too. Cold cache, copy cost subtracted:

| scans of one response | 1 | 2 | 4 |
|---|---|---|---|
| ASCII page | +0.8% | +3.3% | +1.0% |
| non-ASCII page | +2.5% | +5.3% | +9.9% |

Single-scan gain is noise. What the borrow buys is **repeat scans**, where `.encode()` re-transcodes every
time and the cached view does not.

**So take this for the interface, not the speed.** A caller should not have to know the engine wants
bytes, and the mojibake guard is the other reason. If the abi3 floor were not something we wanted to move,
leaving `.encode()` in place would be the honest call.

## Two things worth a reviewer's attention

**Label resolution has to consult both universes.** WHATWG defines `iso-8859-1` but not `latin-1`; Python
defines `utf_8`/`utf-8-sig`/`U8` which WHATWG does not. A native check reading only WHATWG labels let
`latin-1` through (mojibake) while refusing `utf_8` that `extract` accepts — the same argument meaning
different things through the two entry points. `Html::encoding` now performs the same two-step resolution
`frostwork.page._check_encoding` does, and only consults `codecs` when this crate cannot resolve the label
itself. Twelve parametrized cases pin both entry points to the same answer.

**The floor bump found a latent bug.** The `abi3-floor` CI job could not run `pytest` at all on 3.9 —
`parsel`, `web-poet` and `pytest` each require ≥ 3.10 — so it ran `tools/abi3_smoke.py` as a stand-in and
the floor was never covered by the real suite. It now runs the same `pytest tests/` as every other
interpreter, and the first run there failed:

```
RuntimeError: Error calling __set_name__ on '_FrostField' instance 'name' in 'Wrong'
```

`docs/PYTHON.md` promises `TypeError` at class definition for a `field()` on a non-Frostwork base. It is a
`TypeError` — but **CPython before 3.12 re-raises anything out of `__set_name__` wrapped in
`RuntimeError`** ([gh-77757](https://github.com/python/cpython/issues/77757)). The message survives on
`__cause__`; the type does not. `raises_at_class_definition` now asserts what holds on every supported
version, including that 3.12+ delivers the `TypeError` unwrapped so a regression there still fails, and
the docs state the version-dependence.

`tools/abi3_smoke.py` is kept, now for the thing it is the only witness to: the core works with no Python
dependencies present.

## Verification

- Python suite **200 passed on 3.10**, **200 on 3.13**, **203 on 3.14**; `cargo test` 187 passed; clippy
  and mypy clean; `abi3_smoke.py` passes on the floor.
- `str` and `bytes` return equal columns for `extract`, `extract_grouped` and `Plan`, including non-ASCII.
- Against [frostwork-demo](https://github.com/shaneaevans/frostwork-demo): 14 tests pass, a 15-shape
  encoding differential vs Parsel shows **0 divergences**, and a Chromium crawl extracts 22/22 products
  with **0 divergences** from the bytes path.
